### PR TITLE
get_ticket accepts an `id` not an object

### DIFF
--- a/zenpy/lib/api_objects.py
+++ b/zenpy/lib/api_objects.py
@@ -2481,7 +2481,7 @@ class TicketAudit(BaseObject):
     def audit(self):
 
         if self.api and self._audit:
-            return self.api.get_audit(self._audit)
+            return self.api.get_audit(self._audit.id)
 
     @audit.setter
     def audit(self, audit):
@@ -2492,7 +2492,7 @@ class TicketAudit(BaseObject):
     def ticket(self):
 
         if self.api and self._ticket:
-            return self.api.get_ticket(self._ticket)
+            return self.api.get_ticket(self._ticket.id)
 
     @ticket.setter
     def ticket(self, ticket):


### PR DESCRIPTION
currently, calling get_ticket from TicketAudit will call the following url:

    GET: https://MIDOMAIN.zendesk.com/api/v2/tickets/<zenpy.lib.api_objects.Ticket object at 0x10848b190>.json

because a Ticket object is passed. This PR fixes the TicketAudit so that this:

    GET: https://MYDOMAIN.zendesk.com/api/v2/tickets/12345.json

is called instead