### PR TITLE
Specify "id=user_id" kwarg when getting tickets assigned for user.

### DIFF
--- a/zenpy/lib/api.py
+++ b/zenpy/lib/api.py
@@ -503,7 +503,7 @@ class UserApi(TaggableApi, IncrementalApi, CRUDApi):
 
         :param user_id: user id
         """
-        return self._get_items(self.endpoint.assigned, 'ticket', user_id)
+        return self._get_items(self.endpoint.assigned, 'ticket', id=user_id)
 
     def group_memberships(self, user_id):
         """


### PR DESCRIPTION
Was getting this:

```
>>> zp.users.requested(zp.users.me().id)
<zenpy.lib.generator.ResultGenerator object at 0x7f39e482b750>
>>> zp.users.assigned(zp.users.me().id)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ec2-user/concord/local/lib/python2.7/site-packages/zenpy/lib/api.py", line 506, in assigned
    return self._get_items(self.endpoint.assigned, 'ticket', user_id)
  File "/home/ec2-user/concord/local/lib/python2.7/site-packages/zenpy/lib/api.py", line 83, in _get_items
    return self._get_paginated(endpoint, object_type, *args, **kwargs)
  File "/home/ec2-user/concord/local/lib/python2.7/site-packages/zenpy/lib/api.py", line 104, in _get_paginated
    _json = self._query(endpoint=endpoint(*args, **kwargs))
TypeError: __call__() takes exactly 1 argument (2 given)
```

Note that I get the ResultGenerator for requested but not assigned. Turned out the UserApi.assigned method wasn't passing the user_id correctly. Now that it does, I get:

```
>>> zp.users.requested(zp.users.me().id)
<zenpy.lib.generator.ResultGenerator object at 0x7f7d134bd5d0>
>>> zp.users.assigned(zp.users.me().id)
<zenpy.lib.generator.ResultGenerator object at 0x7f7d134656d0>
```