### PR TITLE
Remove misleading doc

### DIFF
--- a/docs/zenpy.rst
+++ b/docs/zenpy.rst
@@ -48,7 +48,6 @@ First, create a :class:`Zenpy` object:
     # An OAuth token
     creds = {
       "subdomain": "yoursubdomain",
-      "email": "youremail",
       "oauth_token": "youroathtoken"
     }
 


### PR DESCRIPTION
There should be no need to pass an email address when using an oauth token.