### PR TITLE
Support role filter in endpoint

### DIFF
--- a/zenpy/lib/endpoint.py
+++ b/zenpy/lib/endpoint.py
@@ -85,6 +85,11 @@ class PrimaryEndpoint(BaseEndpoint):
                 query = "".join([self.endpoint, '/update_many.json'])
             elif key in ('sort_by', 'sort_order'):
                 modifiers.append((key, value))
+            elif key == 'role':
+                if isinstance(value, basestring):
+                   value = [value]
+                for role in value:
+                    modifiers.append(('role[]', role))
             elif key == 'since':
                 modifiers.append((key, value.strftime(self.ISO_8601_FORMAT)))
 


### PR DESCRIPTION
This allows zenpy to support the role filter when making API calls. Someone needs to do the same for permissions, if the maintainer believes this is the right approach to support filters.