### PR TITLE
Permission_set filter, document filter

### DIFF
--- a/docs/zenpy.rst
+++ b/docs/zenpy.rst
@@ -146,6 +146,8 @@ And called with an ID returns the object with that ID:
 
     print zenpy_client.users(id=1159307768)
 
+You can also filter by passing in ``permission_set`` or ``role``.
+
 In addition to the top level endpoints there are several secondary level
 endpoints that reference the level above. For example, if you wanted to
 print all the comments on a ticket:

--- a/zenpy/lib/endpoint.py
+++ b/zenpy/lib/endpoint.py
@@ -85,6 +85,8 @@ class PrimaryEndpoint(BaseEndpoint):
                 query = "".join([self.endpoint, '/update_many.json'])
             elif key in ('sort_by', 'sort_order'):
                 modifiers.append((key, value))
+            elif key == 'permission_set':
+                modifiers.append(('permission_set', value))
             elif key == 'role':
                 if isinstance(value, basestring):
                    value = [value]


### PR DESCRIPTION
This patch addresses permission_set filtering mentioned in #112 and performs documentation asked in #111 

**I did not test permission_set** since I don't have Enterprise, but the logic should be identical as far as I can tell.