### PR TITLE
Feature/recipient addresses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ python-dateutil>=2.6.0
 cachetools>=2.0.0
 nose>=1.3.7
 requests==2.14.2
+yapf==0.18.0
+bs4==0.0.1
+lxml==4.0.0

--- a/specification/zendesk/support_address.json
+++ b/specification/zendesk/support_address.json
@@ -1,0 +1,11 @@
+{
+  "id": 4230701,
+  "brand_id": 47,
+  "default": null,
+  "name": "invent.io",
+  "email":"support@invent.io",
+  "created_at":"2017-06-26T09:25:29Z",
+  "updated_at":"2017-08-16T16:22:57Z",
+  "forwarding_status":"verified",
+  "spf_status":"failed"
+}

--- a/tests/test_api/betamax/TestRecipientAddressCreateUpdateDelete.test_single_object_creation-create-single.json
+++ b/tests/test_api/betamax/TestRecipientAddressCreateUpdateDelete.test_single_object_creation-create-single.json
@@ -1,0 +1,113 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-10-11T08:31:37",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"recipient_address\": {\"email\": \"help@omniwearshop.com\", \"name\": \"Sales\", \"default\": false}}"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "gzip, deflate",
+          "Authorization": "Basic bmljb2xhcy5qYXJlbWVrQHJlY2xhbWFkb3IuZXMvdG9rZW46MEFSUFVzVzlOWmJpZnAza2tiWHZueTU0bVZmdUg3eUdRazFVVkpRMw==",
+          "Connection": "keep-alive",
+          "Content-Length": "92",
+          "Content-type": "application/json",
+          "User-Agent": "Zenpy/1.2"
+        },
+        "method": "POST",
+        "uri": "https://jaremek.zendesk.com/api/v2/recipient_addresses.json?&include="
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"recipient_address\":{\"id\":114095027151,\"brand_id\":114094587791,\"default\":null,\"name\":\"Sales\",\"email\":\"help@omniwearshop.com\",\"created_at\":\"2017-10-11T08:31:37Z\",\"updated_at\":\"2017-10-11T08:31:37Z\",\"forwarding_status\":\"waiting\",\"spf_status\":\"failed\"}}"
+        },
+        "headers": {
+          "Cache-Control": "max-age=0, private, must-revalidate",
+          "Connection": "keep-alive",
+          "Content-Length": "251",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Wed, 11 Oct 2017 08:31:37 GMT",
+          "ETag": "\"57cd07c1ec67ad413ef83fde54375b18\"",
+          "Location": "https://jaremek.zendesk.com/api/v2/recipient_addresses/114095027151.json",
+          "Server": "nginx",
+          "Strict-Transport-Security": "max-age=31536000;",
+          "X-Content-Type-Options": "nosniff",
+          "X-Frame-Options": "SAMEORIGIN",
+          "X-Rack-Cache": "invalidate, pass",
+          "X-Rate-Limit": "400",
+          "X-Rate-Limit-Remaining": "398",
+          "X-Request-Id": "24d93d84-1cd8-494c-c992-0a27526fa680",
+          "X-Runtime": "0.329086",
+          "X-UA-Compatible": "IE=Edge,chrome=1",
+          "X-Zendesk-API-Version": "v2",
+          "X-Zendesk-Application-Version": "v44.19",
+          "X-Zendesk-Origin-Server": "app33.pod13.usw2.zdsys.com",
+          "X-Zendesk-Request-Id": "22b514e7729998b64c0a"
+        },
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "url": "https://jaremek.zendesk.com/api/v2/recipient_addresses.json?&include="
+      }
+    },
+    {
+      "recorded_at": "2017-10-11T08:31:38",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "gzip, deflate",
+          "Authorization": "Basic bmljb2xhcy5qYXJlbWVrQHJlY2xhbWFkb3IuZXMvdG9rZW46MEFSUFVzVzlOWmJpZnAza2tiWHZueTU0bVZmdUg3eUdRazFVVkpRMw==",
+          "Connection": "keep-alive",
+          "Content-type": "application/json",
+          "User-Agent": "Zenpy/1.2"
+        },
+        "method": "GET",
+        "uri": "https://jaremek.zendesk.com/api/v2/brands/114094587791.json&include="
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA4WOy27CMBBF/8VrSOJAFeLvYEVVWUM8EINfsscsivj3DlDUqpvu7Ksz596r2GcIRqirqNkJJWaiVFTbniCjx3PzicFgOTdT9C0k21769nFRWinX3bh+2wzDKJtTiUEshGXT73whAnhkbcbJgQcTc4OFwYdD/1vJZKl7Ez3YwJbvUZzOUPSMLukJA2EW6gCuIOc/mS4EdO82tsDeoeEzmMheOKNcGTZ4gOro9bVFG3RITL50Lh6jUKE6txBkpzOSPsTstTVFqPcPXmePAahm1IQ+uWchF00Z+W00sF30nRyW3biU/VZ2arVRq3HHTE3mDyO7pZTbjgGpVsOdmWMh7SElG47PIbfbF1cO6zi0AQAA",
+          "encoding": "UTF-8",
+          "string": ""
+        },
+        "headers": {
+          "Cache-Control": "must-revalidate, private, max-age=0",
+          "Connection": "keep-alive",
+          "Content-Encoding": "gzip",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Wed, 11 Oct 2017 08:31:38 GMT",
+          "ETag": "W/\"ce3bc7aae06a5934c0338d7e64230fea\"",
+          "Server": "nginx",
+          "Strict-Transport-Security": "max-age=31536000;",
+          "Transfer-Encoding": "chunked",
+          "X-Content-Type-Options": "nosniff",
+          "X-Frame-Options": "SAMEORIGIN",
+          "X-Rack-Cache": "miss",
+          "X-Rate-Limit": "400",
+          "X-Rate-Limit-Remaining": "397",
+          "X-Request-Id": "5ae93f60-2d83-4144-c193-0a27526fa680",
+          "X-Runtime": "0.173474",
+          "X-UA-Compatible": "IE=Edge,chrome=1",
+          "X-Zendesk-API-Version": "v2",
+          "X-Zendesk-Application-Version": "v44.19",
+          "X-Zendesk-Origin-Server": "app4.pod13.usw2.zdsys.com",
+          "X-Zendesk-Request-Id": "e20c6a6b2b701ac25b63"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://jaremek.zendesk.com/api/v2/brands/114094587791.json&include="
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/test_api/betamax/TestRecipientAddressCreateUpdateDelete.test_single_object_creation-tearDown.json
+++ b/tests/test_api/betamax/TestRecipientAddressCreateUpdateDelete.test_single_object_creation-tearDown.json
@@ -1,0 +1,56 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-10-11T08:31:38",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"recipient_address\": {\"name\": \"Sales\", \"forwarding_status\": \"waiting\", \"updated_at\": \"2017-10-11T08:31:37Z\", \"email\": \"help@omniwearshop.com\", \"id\": 114095027151, \"spf_status\": \"failed\", \"created_at\": \"2017-10-11T08:31:37Z\", \"brand_id\": 114094587791}}"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "gzip, deflate",
+          "Authorization": "Basic bmljb2xhcy5qYXJlbWVrQHJlY2xhbWFkb3IuZXMvdG9rZW46MEFSUFVzVzlOWmJpZnAza2tiWHZueTU0bVZmdUg3eUdRazFVVkpRMw==",
+          "Connection": "keep-alive",
+          "Content-Length": "252",
+          "Content-type": "application/json",
+          "User-Agent": "Zenpy/1.2"
+        },
+        "method": "DELETE",
+        "uri": "https://jaremek.zendesk.com/api/v2/recipient_addresses/114095027151.json&include="
+      },
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": ""
+        },
+        "headers": {
+          "Cache-Control": "no-cache",
+          "Connection": "keep-alive",
+          "Date": "Wed, 11 Oct 2017 08:31:38 GMT",
+          "Server": "nginx",
+          "Strict-Transport-Security": "max-age=31536000;",
+          "X-Content-Type-Options": "nosniff",
+          "X-Frame-Options": "SAMEORIGIN",
+          "X-Rack-Cache": "invalidate, pass",
+          "X-Rate-Limit": "400",
+          "X-Rate-Limit-Remaining": "396",
+          "X-Request-Id": "8d466cfa-6f30-4871-c89d-0a27526fa680",
+          "X-Runtime": "0.171987",
+          "X-UA-Compatible": "IE=Edge,chrome=1",
+          "X-Zendesk-API-Version": "v2",
+          "X-Zendesk-API-Warn": "Removed restricted keys [\"recipient_address.name\", \"recipient_address.forwarding_status\", \"recipient_address.updated_at\", \"recipient_address.email\", \"recipient_address.id\", \"recipient_address.spf_status\", \"recipient_address.created_at\", \"recipient_address.brand_id\", \"recipient_address\"] from parameters according to whitelist",
+          "X-Zendesk-Application-Version": "v44.19",
+          "X-Zendesk-Origin-Server": "app3.pod13.usw2.zdsys.com",
+          "X-Zendesk-Request-Id": "8c9ec343ad40e91f177a"
+        },
+        "status": {
+          "code": 204,
+          "message": "No Content"
+        },
+        "url": "https://jaremek.zendesk.com/api/v2/recipient_addresses/114095027151.json&include="
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/test_api/betamax/TestRecipientAddressCreateUpdateDelete.test_single_object_update-tearDown.json
+++ b/tests/test_api/betamax/TestRecipientAddressCreateUpdateDelete.test_single_object_update-tearDown.json
@@ -1,0 +1,56 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-10-11T08:31:40",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"recipient_address\": {\"name\": \"Salesd0edfb6e8c55c8742a83f0f192886e0e15fa0347\", \"forwarding_status\": \"waiting\", \"updated_at\": \"2017-10-11T08:31:39Z\", \"email\": \"help@omniwearshop.com\", \"id\": 114095027171, \"spf_status\": \"failed\", \"created_at\": \"2017-10-11T08:31:39Z\", \"brand_id\": 114094587791}}"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "gzip, deflate",
+          "Authorization": "Basic bmljb2xhcy5qYXJlbWVrQHJlY2xhbWFkb3IuZXMvdG9rZW46MEFSUFVzVzlOWmJpZnAza2tiWHZueTU0bVZmdUg3eUdRazFVVkpRMw==",
+          "Connection": "keep-alive",
+          "Content-Length": "292",
+          "Content-type": "application/json",
+          "User-Agent": "Zenpy/1.2"
+        },
+        "method": "DELETE",
+        "uri": "https://jaremek.zendesk.com/api/v2/recipient_addresses/114095027171.json&include="
+      },
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": ""
+        },
+        "headers": {
+          "Cache-Control": "no-cache",
+          "Connection": "keep-alive",
+          "Date": "Wed, 11 Oct 2017 08:31:40 GMT",
+          "Server": "nginx",
+          "Strict-Transport-Security": "max-age=31536000;",
+          "X-Content-Type-Options": "nosniff",
+          "X-Frame-Options": "SAMEORIGIN",
+          "X-Rack-Cache": "invalidate, pass",
+          "X-Rate-Limit": "400",
+          "X-Rate-Limit-Remaining": "393",
+          "X-Request-Id": "b2ad473b-c619-4f51-cfe0-0a27526fa680",
+          "X-Runtime": "0.182519",
+          "X-UA-Compatible": "IE=Edge,chrome=1",
+          "X-Zendesk-API-Version": "v2",
+          "X-Zendesk-API-Warn": "Removed restricted keys [\"recipient_address.name\", \"recipient_address.forwarding_status\", \"recipient_address.updated_at\", \"recipient_address.email\", \"recipient_address.id\", \"recipient_address.spf_status\", \"recipient_address.created_at\", \"recipient_address.brand_id\", \"recipient_address\"] from parameters according to whitelist",
+          "X-Zendesk-Application-Version": "v44.19",
+          "X-Zendesk-Origin-Server": "app16.pod13.usw2.zdsys.com",
+          "X-Zendesk-Request-Id": "9bae5d8f45a6cb5a9603"
+        },
+        "status": {
+          "code": 204,
+          "message": "No Content"
+        },
+        "url": "https://jaremek.zendesk.com/api/v2/recipient_addresses/114095027171.json&include="
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/test_api/betamax/TestRecipientAddressCreateUpdateDelete.test_single_object_update-update-single.json
+++ b/tests/test_api/betamax/TestRecipientAddressCreateUpdateDelete.test_single_object_update-update-single.json
@@ -1,0 +1,115 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-10-11T08:31:39",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"recipient_address\": {\"email\": \"help@omniwearshop.com\", \"name\": \"Sales\", \"default\": false}}"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "gzip, deflate",
+          "Authorization": "Basic bmljb2xhcy5qYXJlbWVrQHJlY2xhbWFkb3IuZXMvdG9rZW46MEFSUFVzVzlOWmJpZnAza2tiWHZueTU0bVZmdUg3eUdRazFVVkpRMw==",
+          "Connection": "keep-alive",
+          "Content-Length": "92",
+          "Content-type": "application/json",
+          "User-Agent": "Zenpy/1.2"
+        },
+        "method": "POST",
+        "uri": "https://jaremek.zendesk.com/api/v2/recipient_addresses.json?&include="
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"recipient_address\":{\"id\":114095027171,\"brand_id\":114094587791,\"default\":null,\"name\":\"Sales\",\"email\":\"help@omniwearshop.com\",\"created_at\":\"2017-10-11T08:31:39Z\",\"updated_at\":\"2017-10-11T08:31:39Z\",\"forwarding_status\":\"waiting\",\"spf_status\":\"failed\"}}"
+        },
+        "headers": {
+          "Cache-Control": "max-age=0, private, must-revalidate",
+          "Connection": "keep-alive",
+          "Content-Length": "251",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Wed, 11 Oct 2017 08:31:39 GMT",
+          "ETag": "\"390e64da3b2ee5fcc0c0c19d1ab3f7c9\"",
+          "Location": "https://jaremek.zendesk.com/api/v2/recipient_addresses/114095027171.json",
+          "Server": "nginx",
+          "Strict-Transport-Security": "max-age=31536000;",
+          "X-Content-Type-Options": "nosniff",
+          "X-Frame-Options": "SAMEORIGIN",
+          "X-Rack-Cache": "invalidate, pass",
+          "X-Rate-Limit": "400",
+          "X-Rate-Limit-Remaining": "395",
+          "X-Request-Id": "cb510267-bbac-48bc-c899-0a27526fa680",
+          "X-Runtime": "0.306099",
+          "X-UA-Compatible": "IE=Edge,chrome=1",
+          "X-Zendesk-API-Version": "v2",
+          "X-Zendesk-Application-Version": "v44.19",
+          "X-Zendesk-Origin-Server": "app23.pod13.usw2.zdsys.com",
+          "X-Zendesk-Request-Id": "5ace4bd1e1f3bbccce3d"
+        },
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "url": "https://jaremek.zendesk.com/api/v2/recipient_addresses.json?&include="
+      }
+    },
+    {
+      "recorded_at": "2017-10-11T08:31:39",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"recipient_address\": {\"name\": \"Salesd0edfb6e8c55c8742a83f0f192886e0e15fa0347\", \"forwarding_status\": \"waiting\", \"updated_at\": \"2017-10-11T08:31:39Z\", \"email\": \"help@omniwearshop.com\", \"id\": 114095027171, \"spf_status\": \"failed\", \"created_at\": \"2017-10-11T08:31:39Z\", \"brand_id\": 114094587791}}"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "gzip, deflate",
+          "Authorization": "Basic bmljb2xhcy5qYXJlbWVrQHJlY2xhbWFkb3IuZXMvdG9rZW46MEFSUFVzVzlOWmJpZnAza2tiWHZueTU0bVZmdUg3eUdRazFVVkpRMw==",
+          "Connection": "keep-alive",
+          "Content-Length": "292",
+          "Content-type": "application/json",
+          "User-Agent": "Zenpy/1.2"
+        },
+        "method": "PUT",
+        "uri": "https://jaremek.zendesk.com/api/v2/recipient_addresses/114095027171.json&include="
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA4WPMW7DMAxF78LZCUTbimRNvUM7dTEYk2oEyLIhyfAQ5O7R1I5dH9//JJ+QZQl7kFRnYs5SCrgnBAaHOKpJq96gwQ7umRLPv3zU1pipcRZPR6zg0hFjB4lWAQefFKWwEvb3m9hF68WasSc7eOVx6q29iRLUntQwGuhAVgqx5R4S949tTeEUyuWx7ddlW9t8yUJVeKa2CHqF5oLqgvilrBvQDdN3c46d/3X8lk/KHNLPXCrVoz0LJ4XaQGsou//Dvl0kDK/XG+3Zk+UjAQAA",
+          "encoding": "UTF-8",
+          "string": ""
+        },
+        "headers": {
+          "Cache-Control": "max-age=0, private, must-revalidate",
+          "Connection": "keep-alive",
+          "Content-Encoding": "gzip",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Wed, 11 Oct 2017 08:31:39 GMT",
+          "ETag": "W/\"9ac2f003966fff695da09e2f18b7b29a\"",
+          "Server": "nginx",
+          "Strict-Transport-Security": "max-age=31536000;",
+          "Transfer-Encoding": "chunked",
+          "X-Content-Type-Options": "nosniff",
+          "X-Frame-Options": "SAMEORIGIN",
+          "X-Rack-Cache": "invalidate, pass",
+          "X-Rate-Limit": "400",
+          "X-Rate-Limit-Remaining": "394",
+          "X-Request-Id": "b0fb781b-d576-49e3-c91b-0a27526fa680",
+          "X-Runtime": "0.196634",
+          "X-UA-Compatible": "IE=Edge,chrome=1",
+          "X-Zendesk-API-Version": "v2",
+          "X-Zendesk-API-Warn": "Removed restricted keys [\"recipient_address.forwarding_status\", \"recipient_address.updated_at\", \"recipient_address.id\", \"recipient_address.spf_status\", \"recipient_address.created_at\"] from parameters according to whitelist",
+          "X-Zendesk-Application-Version": "v44.19",
+          "X-Zendesk-Origin-Server": "app15.pod13.usw2.zdsys.com",
+          "X-Zendesk-Request-Id": "d87a2d12074d07ec390c"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://jaremek.zendesk.com/api/v2/recipient_addresses/114095027171.json&include="
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/test_api/betamax/TestRecipientAddressCreateUpdateDelete.test_single_update_raises_recordnotfoundexception-recordnotfound-update.json
+++ b/tests/test_api/betamax/TestRecipientAddressCreateUpdateDelete.test_single_update_raises_recordnotfoundexception-recordnotfound-update.json
@@ -1,0 +1,59 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-10-11T08:31:40",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"recipient_address\": {\"email\": \"help@omniwearshop.com\", \"id\": 9223372036854775807, \"default\": false, \"name\": \"Sales\"}}"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "gzip, deflate",
+          "Authorization": "Basic bmljb2xhcy5qYXJlbWVrQHJlY2xhbWFkb3IuZXMvdG9rZW46MEFSUFVzVzlOWmJpZnAza2tiWHZueTU0bVZmdUg3eUdRazFVVkpRMw==",
+          "Connection": "keep-alive",
+          "Content-Length": "119",
+          "Content-type": "application/json",
+          "User-Agent": "Zenpy/1.2"
+        },
+        "method": "PUT",
+        "uri": "https://jaremek.zendesk.com/api/v2/recipient_addresses/9223372036854775807.json&include="
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSi0qyi9SslIKSk3OL0rxyy9xyy/NS1HSUUpJLU4uyiwoyczPA0oDJRTSwDK1AHKmUTI0AAAA",
+          "encoding": "UTF-8",
+          "string": ""
+        },
+        "headers": {
+          "Cache-Control": "no-cache",
+          "Connection": "keep-alive",
+          "Content-Encoding": "gzip",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Wed, 11 Oct 2017 08:31:40 GMT",
+          "Server": "nginx",
+          "Strict-Transport-Security": "max-age=31536000;",
+          "Transfer-Encoding": "chunked",
+          "X-Frame-Options": "SAMEORIGIN",
+          "X-Rack-Cache": "invalidate, pass",
+          "X-Rate-Limit": "400",
+          "X-Rate-Limit-Remaining": "392",
+          "X-Request-Id": "9bf8cf2c-86c6-472b-c73b-0a27526fa680",
+          "X-Runtime": "0.162739",
+          "X-UA-Compatible": "IE=Edge,chrome=1",
+          "X-Zendesk-API-Version": "v2",
+          "X-Zendesk-API-Warn": "Removed restricted keys [\"recipient_address.id\"] from parameters according to whitelist",
+          "X-Zendesk-Application-Version": "v44.19",
+          "X-Zendesk-Origin-Server": "app18.pod13.usw2.zdsys.com",
+          "X-Zendesk-Request-Id": "282741e5027b591f924a"
+        },
+        "status": {
+          "code": 404,
+          "message": "Not Found"
+        },
+        "url": "https://jaremek.zendesk.com/api/v2/recipient_addresses/9223372036854775807.json&include="
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/test_api/fixtures/__init__.py
+++ b/tests/test_api/fixtures/__init__.py
@@ -92,6 +92,11 @@ class ModifiableApiTestCase(ZenpyApiTestCase):
     # from the ZenpyType.
     expected_single_result_type = None
 
+    # Kwargs whose values should not be changed in the the update request.
+    # Some fields in update requests cannot have their value changed
+    # due to Zendesk API constraints.
+    ignore_update_kwargs = []
+
     def setUp(self):
         super(ModifiableApiTestCase, self).setUp()
         self.created_objects = []
@@ -206,7 +211,7 @@ class ModifiableApiTestCase(ZenpyApiTestCase):
 
         new_kwargs = self.object_kwargs.copy()
         for attr_name in new_kwargs:
-            if isinstance(new_kwargs[attr_name], basestring):
+            if isinstance(new_kwargs[attr_name], basestring) and attr_name not in self.ignore_update_kwargs:
                 new_kwargs[attr_name] += hash_of(new_kwargs[attr_name])
                 setattr(zenpy_object, attr_name, new_kwargs[attr_name])
         return zenpy_object, new_kwargs

--- a/tests/test_api/test_create_update_delete.py
+++ b/tests/test_api/test_create_update_delete.py
@@ -1,6 +1,6 @@
 from test_api.fixtures.__init__ import SingleCreateApiTestCase, CRUDApiTestCase, \
     SingleUpdateApiTestCase, SingleDeleteApiTestCase
-from zenpy.lib.api_objects import Ticket, TicketAudit, Group, User, Organization, Macro
+from zenpy.lib.api_objects import Ticket, TicketAudit, Group, User, Organization, Macro, RecipientAddress
 
 
 class TestTicketCreateUpdateDelete(CRUDApiTestCase):
@@ -41,3 +41,11 @@ class TestMacrosCreateUpdateDelete(SingleUpdateApiTestCase, SingleCreateApiTestC
     ZenpyType = Macro
     object_kwargs = dict(title='TestMacro', actions=[{"field": "status", "value": "solved"}])
     api_name = 'macros'
+
+
+class TestRecipientAddressCreateUpdateDelete(SingleUpdateApiTestCase, SingleCreateApiTestCase):
+    __test__ = True
+    ZenpyType = RecipientAddress
+    object_kwargs = dict(name='Sales', email='help@omniwearshop.com')
+    ignore_update_kwargs = ['email']  # Email value cannot be changed after creation
+    api_name = 'recipient_addresses'

--- a/zenpy/__init__.py
+++ b/zenpy/__init__.py
@@ -22,7 +22,7 @@ from zenpy.lib.api import (
     SlaPolicyApi,
     ChatApi,
     GroupMembershipApi,
-    SupportAddressApi)
+    RecipientAddressApi)
 from zenpy.lib.cache import ZenpyCache, cache_mapping, purge_cache
 from zenpy.lib.endpoint import EndpointFactory
 from zenpy.lib.exception import ZenpyException
@@ -145,7 +145,7 @@ class Zenpy(object):
 
         self.sla_policies = SlaPolicyApi(config)
 
-        self.support_addresses = SupportAddressApi(config)
+        self.recipient_addresses = RecipientAddressApi(config)
 
     def _init_session(self, email, token, oath_token, password, session):
         if not session:

--- a/zenpy/__init__.py
+++ b/zenpy/__init__.py
@@ -21,7 +21,8 @@ from zenpy.lib.api import (
     ViewApi,
     SlaPolicyApi,
     ChatApi,
-    GroupMembershipApi)
+    GroupMembershipApi,
+    SupportAddressApi)
 from zenpy.lib.cache import ZenpyCache, cache_mapping, purge_cache
 from zenpy.lib.endpoint import EndpointFactory
 from zenpy.lib.exception import ZenpyException
@@ -143,6 +144,8 @@ class Zenpy(object):
         self.views = ViewApi(config)
 
         self.sla_policies = SlaPolicyApi(config)
+
+        self.support_addresses = SupportAddressApi(config)
 
     def _init_session(self, email, token, oath_token, password, session):
         if not session:

--- a/zenpy/lib/api.py
+++ b/zenpy/lib/api.py
@@ -1122,6 +1122,11 @@ class SlaPolicyApi(CRUDApi):
         return self._get(url)
 
 
+class SupportAddressApi(CRUDApi):
+    def __init__(self, config):
+        super(SupportAddressApi, self).__init__(config, object_type='support_address')
+
+
 class ChatApiBase(Api):
     """
     Implements most generic ChatApi functionality. Most if the actual work is delegated to

--- a/zenpy/lib/api.py
+++ b/zenpy/lib/api.py
@@ -1122,9 +1122,9 @@ class SlaPolicyApi(CRUDApi):
         return self._get(url)
 
 
-class SupportAddressApi(CRUDApi):
+class RecipientAddressApi(CRUDApi):
     def __init__(self, config):
-        super(SupportAddressApi, self).__init__(config, object_type='support_address')
+        super(RecipientAddressApi, self).__init__(config, object_type='recipient_address')
 
 
 class ChatApiBase(Api):

--- a/zenpy/lib/api_objects/__init__.py
+++ b/zenpy/lib/api_objects/__init__.py
@@ -2225,6 +2225,69 @@ class Status(BaseObject):
             setattr(self, key, value)
 
 
+class SupportAddress(BaseObject):
+    def __init__(self,
+                 api=None,
+                 brand_id=None,
+                 created_at=None,
+                 default=None,
+                 email=None,
+                 forwarding_status=None,
+                 id=None,
+                 name=None,
+                 spf_status=None,
+                 updated_at=None,
+                 **kwargs):
+
+        self.api = api
+        self.brand_id = brand_id
+        self.created_at = created_at
+        self.default = default
+        self.email = email
+        self.forwarding_status = forwarding_status
+        self.id = id
+        self.name = name
+        self.spf_status = spf_status
+        self.updated_at = updated_at
+
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    @property
+    def brand(self):
+
+        if self.api and self.brand_id:
+            return self.api._get_brand(self.brand_id)
+
+    @brand.setter
+    def brand(self, brand):
+        if brand:
+            self.brand_id = brand.id
+            self._brand = brand
+
+    @property
+    def created(self):
+
+        if self.created_at:
+            return dateutil.parser.parse(self.created_at)
+
+    @created.setter
+    def created(self, created):
+        if created:
+            self.created_at = created
+
+    @property
+    def updated(self):
+
+        if self.updated_at:
+            return dateutil.parser.parse(self.updated_at)
+
+    @updated.setter
+    def updated(self, updated):
+        if updated:
+            self.updated_at = updated
+
+
 class SuspendedTicket(BaseObject):
     def __init__(self,
                  api=None,

--- a/zenpy/lib/api_objects/__init__.py
+++ b/zenpy/lib/api_objects/__init__.py
@@ -2225,7 +2225,7 @@ class Status(BaseObject):
             setattr(self, key, value)
 
 
-class SupportAddress(BaseObject):
+class RecipientAddress(BaseObject):
     def __init__(self,
                  api=None,
                  brand_id=None,

--- a/zenpy/lib/api_objects/__init__.py
+++ b/zenpy/lib/api_objects/__init__.py
@@ -2230,7 +2230,7 @@ class RecipientAddress(BaseObject):
                  api=None,
                  brand_id=None,
                  created_at=None,
-                 default=None,
+                 default=False,
                  email=None,
                  forwarding_status=None,
                  id=None,

--- a/zenpy/lib/endpoint.py
+++ b/zenpy/lib/endpoint.py
@@ -493,7 +493,7 @@ class EndpointFactory(object):
     views.execute = SecondaryEndpoint('views/%(id)s/execute.json')
     views.export = SecondaryEndpoint('views/%(id)s/export.json')
     views.search = ViewSearchEndpoint('views/search.json?')
-    support_addresses = PrimaryEndpoint('recipient_addresses')
+    recipient_addresses = PrimaryEndpoint('recipient_addresses')
 
     def __new__(cls, endpoint_name):
         return getattr(cls, endpoint_name)

--- a/zenpy/lib/endpoint.py
+++ b/zenpy/lib/endpoint.py
@@ -493,6 +493,7 @@ class EndpointFactory(object):
     views.execute = SecondaryEndpoint('views/%(id)s/execute.json')
     views.export = SecondaryEndpoint('views/%(id)s/export.json')
     views.search = ViewSearchEndpoint('views/search.json?')
+    support_addresses = PrimaryEndpoint('recipient_addresses')
 
     def __new__(cls, endpoint_name):
         return getattr(cls, endpoint_name)

--- a/zenpy/lib/mapping.py
+++ b/zenpy/lib/mapping.py
@@ -80,7 +80,8 @@ class ZendeskObjectMapping(object):
         'export': Export,
         'sla_policy': SlaPolicy,
         'policy_metric': PolicyMetric,
-        'definitions': Definitions
+        'definitions': Definitions,
+        'recipient_address': SupportAddress
     }
 
     def __init__(self, api):

--- a/zenpy/lib/mapping.py
+++ b/zenpy/lib/mapping.py
@@ -81,7 +81,7 @@ class ZendeskObjectMapping(object):
         'sla_policy': SlaPolicy,
         'policy_metric': PolicyMetric,
         'definitions': Definitions,
-        'recipient_address': SupportAddress
+        'recipient_address': RecipientAddress
     }
 
     def __init__(self, api):

--- a/zenpy/lib/util.py
+++ b/zenpy/lib/util.py
@@ -37,6 +37,8 @@ def as_singular(result_key):
         return re.sub('ies$', 'y', result_key)
     elif result_key.endswith('uses'):
         return re.sub("uses$", "us", result_key)
+    elif result_key.endswith('addresses'):  # Special case for '*addresses'
+        return result_key[:-2]
     elif result_key.endswith('s'):
         return result_key[:-1]
     else:
@@ -50,6 +52,8 @@ def as_plural(result_key):
     # Not at all guaranteed to work in all cases...
     if result_key.endswith('y'):
         return re.sub("y$", "ies", result_key)
+    elif result_key.endswith('address'):
+        return result_key + 'es'
     elif result_key.endswith('us'):
         return re.sub("us$", "uses", result_key)
     elif not result_key.endswith('s'):


### PR DESCRIPTION
Hello there!

We came across this nice *Zendesk* API wrapper, and started using it for our own *Zendesk* integrations. However, we noticed a missing feature needed in our current project, which consists on fetching a list of the available [recipient addresses associated to a *Zendesk* account](https://developer.zendesk.com/rest_api/docs/core/support_addresses). 

This pull request adds such functionality, trying to replicate as much as possible the current logic layout. However, the corresponding test cases are missing. Some tests exist in the repository, but apparently they perform real HTTP requests against a *Zendesk* account. More info on this would be greatly appreciated in order to improve the test suite. Also, I cannot seem to find the command or flow to run the existing tests.

Finally, the requirements file has been updated with the missing dependencies I came across and had to install manually apart from the mandatory `pip install`.

Let me know if there are any doubts or invalid logic associated with this code.

Thanks in advance!