### PR TITLE
Fix for *_between throwing away time and time zone

### DIFF
--- a/zenpy/lib/endpoint.py
+++ b/zenpy/lib/endpoint.py
@@ -31,8 +31,10 @@ log = logging.getLogger(__name__)
 class BaseEndpoint(object):
     """
     BaseEndpoint supplies common formatting operations.
+   
     """
-
+    ISO_8601_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
+    
     def __init__(self, endpoint, sideload=None):
         self.endpoint = endpoint
         self.sideload = sideload or []
@@ -62,9 +64,7 @@ class PrimaryEndpoint(BaseEndpoint):
     """
     A PrimaryEndpoint takes an id or list of ids and either returns the objects
     associated with them or performs actions on them (eg, update/delete).
-    """
-
-    ISO_8601_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
+    """ 
 
     def __call__(self, **kwargs):
         query = ""
@@ -211,7 +211,7 @@ class SearchEndpoint(BaseEndpoint):
 
     """
 
-    ZENDESK_DATE_FORMAT_NAIVE = "%Y-%m-%dT%H:%M:%SZ"
+    ZENDESK_DATE_FORMAT = "%Y-%m-%d"
 
     def __call__(self, *args, **kwargs):
 
@@ -267,7 +267,7 @@ class SearchEndpoint(BaseEndpoint):
             raise ZenpyException("*_between only works with dates!")
         key = key.replace('_between', '')
         if values[0].tzinfo is None or values[1].tzinfo is None:
-            dates = [v.strftime(self.ZENDESK_DATE_FORMAT_NAIVE) for v in values]
+            dates = [v.strftime(self.ISO_8601_FORMAT) for v in values]
         else:
             dates = [str(v.replace(microsecond=0).isoformat()) for v in values]
         return "%s>%s %s<%s" % (key, dates[0], key, dates[1])

--- a/zenpy/lib/endpoint.py
+++ b/zenpy/lib/endpoint.py
@@ -31,8 +31,8 @@ log = logging.getLogger(__name__)
 class BaseEndpoint(object):
     """
     BaseEndpoint supplies common formatting operations.
-   
     """
+    
     ISO_8601_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
     
     def __init__(self, endpoint, sideload=None):

--- a/zenpy/lib/endpoint.py
+++ b/zenpy/lib/endpoint.py
@@ -211,7 +211,7 @@ class SearchEndpoint(BaseEndpoint):
 
     """
 
-    ZENDESK_DATE_FORMAT = "%Y-%m-%d"
+    ZENDESK_DATE_FORMAT_NAIVE = "%Y-%m-%dT%H:%M:%SZ"
 
     def __call__(self, *args, **kwargs):
 
@@ -266,7 +266,10 @@ class SearchEndpoint(BaseEndpoint):
         elif not all([isinstance(d, datetime) for d in values]):
             raise ZenpyException("*_between only works with dates!")
         key = key.replace('_between', '')
-        dates = [v.strftime(self.ZENDESK_DATE_FORMAT) for v in values]
+        if values[0].tzinfo is None or values[1].tzinfo is None:
+            dates = [v.strftime(self.ZENDESK_DATE_FORMAT_NAIVE) for v in values]
+        else:
+            dates = [str(v.replace(microsecond=0).isoformat()) for v in values]
         return "%s>%s %s<%s" % (key, dates[0], key, dates[1])
 
     def format_or(self, key, values):


### PR DESCRIPTION
This should fix the bug for *_between that throws away data. I am currently using this fix to run my software. That being said, I discovered a bug in zendesk where a timezone that uses a "+" will return an error in zendesk and with a - it will work. 

Example:

https://subdomain.zendesk.com/api/v2/search.json?query=type:"ticket"+created>2015-09-01T12:00:00-00:00 works!

https://subdomain.zendesk.com/api/v2/search.json?query=type:"ticket"+created>2015-09-01T12:00:00+00:00 does not work

I notified Zendesk of the bug and here is their response (see engineer response at bottom):

(10:47:53 AM) Joshua Miller: No when I use a + timezone offset it does nto work
(10:48:09 AM) Joshua Miller: and when I use a - timezone offset it works
(10:48:32 AM) Joshua Miller: So I can do a search for UTC-05:00
(10:48:42 AM) Joshua Miller: but not UTC+05:00
(10:51:24 AM) Joshua Miller: you can close the chat again if you have to
(10:51:50 AM) Russel: I'm going to add this to the email that I'll forward to our Support Engineers
(10:51:59 AM) Russel: Thank you for the information.
(10:52:14 AM) Joshua Miller: yes, summary is
(10:52:18 AM) Joshua Miller: created>2015-09-01T12:00:00+08:00 does not work
(10:52:26 AM) Joshua Miller: created>2015-09-01T12:00:00-08:00 does work

Valeriya Bozhinova (Zendesk Support) 
16 nov. 01:36 PST 

Here is the response from the engineer:

Hi Joshua,

My name is Valeriya, I am on the technical support and engineering team based in Dublin, Ireland.

Thanks for bringing this to our attention! This definitely looks like a bug so I am passing the issue further to the third level support and our developers to investigate.

We will be in touch with you once we have more news for you. For now as a temporary workaround could you kindly use the UTC timezone when making Search requests, for example: 

updated<2015-09-01T12:00:00Z
Thank you for your patience!
Best regards,
Valeriya Bozhinova | Technical Support Engineer | Zendesk Certified Support Admin | Dublin, Ireland | support@zendesk.com