### PR TITLE
Add coveralls to Travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.6"
   - "3.7-dev"
 install:
+  - pip install -r requirements.txt
   - pip install coverage
   - pip install python-coveralls
 script: "nosetests --with-coverage --cover-package=zenpy -v --stop"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,5 @@ install:
   - pip install coverage
   - pip install python-coveralls
 script: "nosetests --with-coverage --cover-package=zenpy -v --stop"
+after_success:
+  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7-dev"
-script: "nosetests -v --stop"
+install:
+  - pip install coverage
+  - pip install python-coveralls
+script: "nosetests --with-coverage --cover-package=zenpy -v --stop"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://travis-ci.org/Kilo59/zenpy.svg?branch=master)](https://travis-ci.org/Kilo59/zenpy)
-[![Coverage Status](https://coveralls.io/repos/github/Kilo59/zenpy/badge.svg?branch=master&service=github)](https://coveralls.io/github/Kilo59/zenpy?branch=master&service=github)
+[![Build Status](https://travis-ci.org/facetoe/zenpy.svg?branch=master)](https://travis-ci.org/facetoe/zenpy)
+[![Coverage Status](https://coveralls.io/repos/github/zenpy/badge.svg?branch=master&service=github)](https://coveralls.io/github/zenpy?branch=master&service=github)
 
 # Zenpy
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/facetoe/zenpy.svg?branch=master)](https://travis-ci.org/facetoe/zenpy)
+[![Build Status](https://travis-ci.org/Kilo59/zenpy.svg?branch=master)](https://travis-ci.org/Kilo59/zenpy)
 [![Coverage Status](https://coveralls.io/repos/github/Kilo59/zenpy/badge.svg?branch=master&service=github)](https://coveralls.io/github/Kilo59/zenpy?branch=master&service=github)
 
 # Zenpy

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/facetoe/zenpy.svg?branch=master)](https://travis-ci.org/facetoe/zenpy)
+[![Coverage Status](https://coveralls.io/repos/github/Kilo59/zenpy/badge.svg?branch=master&service=github)](https://coveralls.io/github/Kilo59/zenpy?branch=master&service=github)
 
 # Zenpy
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/facetoe/zenpy.svg?branch=master)](https://travis-ci.org/facetoe/zenpy)
-[![Coverage Status](https://coveralls.io/repos/github/zenpy/badge.svg?branch=master&service=github)](https://coveralls.io/github/zenpy?branch=master&service=github)
+[![Coverage Status](https://coveralls.io/repos/github/facetoe/zenpy/badge.svg?branch=master&service=github)](https://coveralls.io/github/facetoe/zenpy?branch=master&service=github)
 
 # Zenpy
 


### PR DESCRIPTION
use `coverage` and `python-coveralls` to make use of [coveralls](https://coveralls.io/)
Track how much code is covered by current `nosetests`

- [x] The `readMe.md` badges are referencing my fork, need to change if pull request accepted.  

### example coveralls build report for this pull request
https://coveralls.io/github/Kilo59/zenpy
https://coveralls.io/builds/14870915
  