### PR TITLE
changed behaviour of supplied dates vs datetimes

### DIFF
--- a/zenpy/lib/endpoint.py
+++ b/zenpy/lib/endpoint.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime
+from datetime import date
 
 
 from zenpy.lib.exception import ZenpyException


### PR DESCRIPTION
The zendesk API supports searching for datetimes to, if they are ISO_8601 format. (https://support.zendesk.com/hc/en-us/articles/203663226-Zendesk-Support-search-reference#topic_ghr_wsc_3v)
Before, supplied datetimes where formatted to dates. Now, if somebody supplies a date, we will format the date, otherwise we format the datetime to ISO_8601 format.