### PR TITLE
Fix generator to not crash if next_page is None

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,66 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# pyenv
+.python-version
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Zenpy specific
+!zenpy/lib

--- a/zenpy/lib/endpoint.py
+++ b/zenpy/lib/endpoint.py
@@ -155,7 +155,7 @@ class IncrementalEndpoint(BaseEndpoint):
 
     def __call__(self, start_time=None):
         if start_time is None:
-            raise ZenpyException("Incremental Endoint requires a start_time parameter!")
+            raise ZenpyException("Incremental Endpoint requires a start_time parameter!")
 
         elif isinstance(start_time, datetime):
             unix_time = to_unix_ts(start_time)

--- a/zenpy/lib/generator.py
+++ b/zenpy/lib/generator.py
@@ -96,7 +96,8 @@ class BaseResultGenerator(collections.Iterable):
         if any((val < 0 for val in (start, stop, page_size))):
             raise ValueError("negative values not supported in slice operations!")
 
-        if 'incremental' in self._response_json.get("next_page", ''):
+        next_page = self._response_json.get("next_page")
+        if next_page and 'incremental' in next_page:
             raise NotImplementedError("the current slice implementation does not support incremental APIs!")
 
         if self._response_json.get("before_cursor", None):


### PR DESCRIPTION
I have a sandbox store with only about 40 tickets. Every time I try to do `client.tickets()[0:1]` I'm getting a crash:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/lib/python3.6/site-packages/zenpy/lib/generator.py", line 86, in __getitem__
    return self._handle_slice(item)
  File "/lib/python3.6/site-packages/zenpy/lib/generator.py", line 99, in _handle_slice
    if 'incremental' in self._response_json.get("next_page", ''):
TypeError: argument of type 'NoneType' is not iterable
```
It's because `next_page` key is there, but it's value is `None`. In other parts of the codebase we expect `next_page` to be `None`, but here we don't.

I tried to add some tests but we have quite sensitive data in our sandbox, I'm not sure how to obfuscate it.

Also this PR:
* adds gitignore file (suggested by Github with some things polished for zenpy repo), to make entire process of contribution less painful.
* fixes typo in string