### PR TITLE
Content type for custom attachment file exstensions

### DIFF
--- a/zenpy/lib/api.py
+++ b/zenpy/lib/api.py
@@ -79,7 +79,7 @@ class BaseApi(object):
         self._dirty_object = None
 
     def _post(self, url, payload, **kwargs):
-        headers = {'Content-Type': 'application/octet-stream'} if 'data' in kwargs else None
+        headers = {'Content-Type': 'application/*'} if 'data' in kwargs else None
         response = self._call_api(self.session.post, url,
                                   json=self._serialize(payload),
                                   timeout=self.timeout,

--- a/zenpy/lib/api.py
+++ b/zenpy/lib/api.py
@@ -78,8 +78,14 @@ class BaseApi(object):
         # is successfully processed, and then call the objects _clean_dirty() method.
         self._dirty_object = None
 
-    def _post(self, url, payload, **kwargs):
-        headers = {'Content-Type': 'application/*'} if 'data' in kwargs else None
+    def _post(self, url, payload, content_type = None, **kwargs):
+        if 'data' in kwargs:
+            if content_type:
+                headers = {'Content-Type': content_type}
+            else:
+                headers = {'Content-Type': 'application/octet-stream'}
+        else:
+            headers = None
         response = self._call_api(self.session.post, url,
                                   json=self._serialize(payload),
                                   timeout=self.timeout,
@@ -772,7 +778,7 @@ class AttachmentApi(Api):
             raise ZenpyException("Attachment endpoint requires an id")
         return Api.__call__(self, **kwargs)
 
-    def upload(self, fp, token=None, target_name=None):
+    def upload(self, fp, token=None, target_name=None, content_type = None):
         """
         Upload a file to Zendesk.
 
@@ -783,7 +789,7 @@ class AttachmentApi(Api):
         :return: :class:`Upload` object containing a token and other information
                     (see https://developer.zendesk.com/rest_api/docs/core/attachments#uploading-files)
         """
-        return UploadRequest(self).post(fp, token=token, target_name=target_name)
+        return UploadRequest(self).post(fp, token=token, target_name=target_name, content_type=content_type)
 
     def download(self, attachment_id, destination):
         """

--- a/zenpy/lib/request.py
+++ b/zenpy/lib/request.py
@@ -214,7 +214,7 @@ class UserIdentityRequest(BaseZendeskRequest):
 class UploadRequest(RequestHandler):
     """ Handles uploading files to Zendesk. """
 
-    def post(self, fp, token=None, target_name=None):
+    def post(self, fp, token=None, target_name=None, content_type=None):
         if hasattr(fp, 'read'):
             # File-like objects such as:
             #   PY3: io.StringIO, io.TextIOBase, io.BufferedIOBase
@@ -238,7 +238,7 @@ class UploadRequest(RequestHandler):
             raise ZenpyException("upload requires a target file name")
 
         url = self.api._build_url(self.api.endpoint.upload(filename=target_name, token=token))
-        return self.api._post(url, data=fp, payload={})
+        return self.api._post(url, data=fp, payload={}, content_type=content_type)
 
     def put(self, api_objects, *args, **kwargs):
         raise NotImplementedError("POST is not implemented fpr UploadRequest!")


### PR DESCRIPTION
Faced a problem - now Zendesk doesn't accept files with unknown extensions - returns error 422. Support has helped me, these files must have a special content-type - "application/*". But if I change the standard zenpy content type, Zendesk stops generate thumbnails for pictures, so it's not a solution.
My variant is to pass a content_type parameter when it is needed.
I had to change the very basic lib functions, hope my changes havn't broken something else :)

New upload style looks like this:
```
ct, enc = mimetypes.guess_type(file_name)
ct = 'application/*' if not ct
zenpy.attachments.upload(path, target_name=file_name, content_type = ct)
```

The old style has to work too:
`zenpy.attachments.upload(path, target_name=file_name)`
if you don't need custom content types