### PR TITLE
adding request_interval instead of 10 sec hardcode value

### DIFF
--- a/zenpy/__init__.py
+++ b/zenpy/__init__.py
@@ -69,7 +69,7 @@ class Zenpy(object):
                  timeout=None,
                  ratelimit=None,
                  ratelimit_budget=None,
-                 request_interval=None):
+                 ratelimit_request_interval=None):
         """
         Python Wrapper for the Zendesk API.
 
@@ -89,7 +89,7 @@ class Zenpy(object):
         :param timeout: global timeout on API requests.
         :param ratelimit: user specified rate limit
         :param ratelimit_budget: maximum time to spend being rate limited
-        :param request_interval: The interval in seconds between requests to Zendesk.
+        :param ratelimit_request_interval: The interval in seconds between requests to Zendesk.
         """
 
         session = self._init_session(email, token, oauth_token, password, session)
@@ -102,7 +102,7 @@ class Zenpy(object):
             timeout=timeout,
             ratelimit=int(ratelimit) if ratelimit is not None else None,
             ratelimit_budget=int(ratelimit_budget) if ratelimit_budget is not None else None,
-            request_interval=int(request_interval) if request_interval else 10,
+            ratelimit_request_interval=int(ratelimit_request_interval) if ratelimit_request_interval else 10,
         )
 
         self.users = UserApi(config)

--- a/zenpy/__init__.py
+++ b/zenpy/__init__.py
@@ -68,7 +68,8 @@ class Zenpy(object):
                  session=None,
                  timeout=None,
                  ratelimit=None,
-                 ratelimit_budget=None):
+                 ratelimit_budget=None,
+                 request_interval=None):
         """
         Python Wrapper for the Zendesk API.
 
@@ -88,6 +89,7 @@ class Zenpy(object):
         :param timeout: global timeout on API requests.
         :param ratelimit: user specified rate limit
         :param ratelimit_budget: maximum time to spend being rate limited
+        :param request_interval: The interval in seconds between requests to Zendesk.
         """
 
         session = self._init_session(email, token, oauth_token, password, session)
@@ -99,7 +101,8 @@ class Zenpy(object):
             session=session,
             timeout=timeout,
             ratelimit=int(ratelimit) if ratelimit is not None else None,
-            ratelimit_budget=int(ratelimit_budget) if ratelimit_budget is not None else None
+            ratelimit_budget=int(ratelimit_budget) if ratelimit_budget is not None else None,
+            request_interval=int(request_interval) if request_interval else 10,
         )
 
         self.users = UserApi(config)

--- a/zenpy/lib/api.py
+++ b/zenpy/lib/api.py
@@ -47,7 +47,7 @@ class BaseApi(object):
     rate limiting and deserializing responses.
     """
 
-    def __init__(self, subdomain, session, timeout, ratelimit, ratelimit_budget):
+    def __init__(self, subdomain, session, timeout, ratelimit, ratelimit_budget, request_interval):
         self.domain = 'zendesk.com'
         self.subdomain = subdomain
         self.session = session
@@ -61,6 +61,7 @@ class BaseApi(object):
             'lastcalltime': None,
             'lastlimitremaining': None
         }
+        self.request_interval = request_interval
         self._response_handlers = (
             DeleteResponseHandler,
             TagResponseHandler,
@@ -160,16 +161,17 @@ class BaseApi(object):
 
         lastlimitremaining = self.callsafety['lastlimitremaining']
 
-        if time_since_last_call() is None or time_since_last_call() >= 10 or lastlimitremaining >= self.ratelimit:
+        if time_since_last_call() is None or time_since_last_call() >= self.request_interval or \
+            lastlimitremaining >= self.ratelimit:
             response = http_method(url, **kwargs)
         else:
-            # We hit our limit floor and aren't quite at 10 seconds yet..
+            # We hit our limit floor and aren't quite at request_interval value in seconds yet..
             log.warn(
-                "Safety Limit Reached of %s remaining calls and time since last call is under 10 seconds"
-                % self.ratelimit
+                "Safety Limit Reached of %s remaining calls and time since last call is under %s seconds"
+                % (self.ratelimit, self.request_interval)
             )
-            while time_since_last_call() < 10:
-                remaining_sleep = int(10 - time_since_last_call())
+            while time_since_last_call() < self.request_interval:
+                remaining_sleep = int(self.request_interval - time_since_last_call())
                 log.debug("  -> sleeping: %s more seconds" % remaining_sleep)
                 sleep(1)
             response = http_method(url, **kwargs)

--- a/zenpy/lib/api.py
+++ b/zenpy/lib/api.py
@@ -47,7 +47,7 @@ class BaseApi(object):
     rate limiting and deserializing responses.
     """
 
-    def __init__(self, subdomain, session, timeout, ratelimit, ratelimit_budget, request_interval):
+    def __init__(self, subdomain, session, timeout, ratelimit, ratelimit_budget, ratelimit_request_interval):
         self.domain = 'zendesk.com'
         self.subdomain = subdomain
         self.session = session
@@ -61,7 +61,7 @@ class BaseApi(object):
             'lastcalltime': None,
             'lastlimitremaining': None
         }
-        self.request_interval = request_interval
+        self.ratelimit_request_interval = ratelimit_request_interval
         self._response_handlers = (
             DeleteResponseHandler,
             TagResponseHandler,
@@ -161,17 +161,17 @@ class BaseApi(object):
 
         lastlimitremaining = self.callsafety['lastlimitremaining']
 
-        if time_since_last_call() is None or time_since_last_call() >= self.request_interval or \
+        if time_since_last_call() is None or time_since_last_call() >= self.ratelimit_request_interval or \
             lastlimitremaining >= self.ratelimit:
             response = http_method(url, **kwargs)
         else:
-            # We hit our limit floor and aren't quite at request_interval value in seconds yet..
+            # We hit our limit floor and aren't quite at ratelimit_request_interval value in seconds yet..
             log.warn(
                 "Safety Limit Reached of %s remaining calls and time since last call is under %s seconds"
-                % (self.ratelimit, self.request_interval)
+                % (self.ratelimit, self.ratelimit_request_interval)
             )
-            while time_since_last_call() < self.request_interval:
-                remaining_sleep = int(self.request_interval - time_since_last_call())
+            while time_since_last_call() < self.ratelimit_request_interval:
+                remaining_sleep = int(self.ratelimit_request_interval - time_since_last_call())
                 log.debug("  -> sleeping: %s more seconds" % remaining_sleep)
                 sleep(1)
             response = http_method(url, **kwargs)


### PR DESCRIPTION
Hi,

I've added a new value in Zenpy object to manage interval between two requests to Zendesk API. Default value is 10 sec