### PR TITLE
Fix storing X-Rate-Limit-Remaining header as string

### DIFF
--- a/zenpy/lib/api.py
+++ b/zenpy/lib/api.py
@@ -185,7 +185,7 @@ class BaseApi(object):
             response = http_method(url, **kwargs)
 
         self.callsafety['lastcalltime'] = time()
-        self.callsafety['lastlimitremaining'] = response.headers.get('X-Rate-Limit-Remaining', 0)
+        self.callsafety['lastlimitremaining'] = int(response.headers.get('X-Rate-Limit-Remaining', 0))
         return response
 
     def _update_callsafety(self, response):


### PR DESCRIPTION
Hi there!

Using zenpy I ran into a bug on an essential account with a few req/min:

```
Traceback (most recent call last):
  File "/virtualenv/project-OdyMjCZJ/lib/python3.7/site-packages/dramatiq/worker.py", line 397, in process_message
    res = actor(*message.args, **message.kwargs)
  File "/virtualenv/project-OdyMjCZJ/lib/python3.7/site-packages/dramatiq/actor.py", line 213, in __call__
    return self.fn(*args, **kwargs)
  File "./app/integrations/zendesk/tasks.py", line 68, in sync_zendesk
    for audit in client.tickets.audits(ticket=ticket.id):
  File "/virtualenv/project-OdyMjCZJ/lib/python3.7/site-packages/zenpy/lib/util.py", line 110, in inner
    return func(*new_args, **new_kwargs)
  File "/virtualenv/project-OdyMjCZJ/lib/python3.7/site-packages/zenpy/lib/api.py", line 1042, in audits
    return self._query_zendesk(self.endpoint.audits, 'ticket_audit', id=ticket, include=include)
  File "/virtualenv/project-OdyMjCZJ/lib/python3.7/site-packages/zenpy/lib/api.py", line 248, in _query_zendesk
    return self._get(url=self._build_url(endpoint(*endpoint_args, **endpoint_kwargs)))
  File "/virtualenv/project-OdyMjCZJ/lib/python3.7/site-packages/zenpy/lib/api.py", line 104, in _get
    response = self._call_api(self.session.get, url, timeout=self.timeout, **kwargs)
  File "/virtualenv/project-OdyMjCZJ/lib/python3.7/site-packages/zenpy/lib/api.py", line 123, in _call_api
    response = self._ratelimit(http_method=http_method, url=url, **kwargs)
  File "/virtualenv/project-OdyMjCZJ/lib/python3.7/site-packages/zenpy/lib/api.py", line 164, in _ratelimit
    lastlimitremaining >= self.ratelimit:
TypeError: '>=' not supported between instances of 'str' and 'int'
```

This should fix the issue, as now is converted to `int` the same way as in the method just below that one.

I haven't seen any specific contribution guidelines, hope everything is ok (is such a small change!).