### PR TITLE
Help center attachment issues

### DIFF
--- a/zenpy/lib/api.py
+++ b/zenpy/lib/api.py
@@ -1764,11 +1764,13 @@ class ArticleAttachmentApi(HelpCentreApiBase, SubscriptionApi):
         return self._query_zendesk(self.endpoint, 'article_attachment', id=attachment)
 
     @extract_id(Article)
-    def create(self, article, attachment, inline=False):
+    def create(self, article, attachment, inline=False, file_name=None, content_type = None):
         return HelpdeskAttachmentRequest(self).post(self.endpoint.create,
                                                     article=article,
                                                     attachment=attachment,
-                                                    inline=inline)
+                                                    inline=inline,
+                                                    file_name=file_name,
+                                                    content_type=content_type)
 
     def create_unassociated(self, attachment, inline=False):
         return HelpdeskAttachmentRequest(self).post(self.endpoint.create_unassociated,


### PR DESCRIPTION
Solved two problems:
1. Inline parameter wasn't used.
2. Setting file name and content type.