### PR TITLE
Fix and document on ArticleAttachments endpoint, allowing changing na…

### DIFF
--- a/specification/help_centre/article_attachment.json
+++ b/specification/help_centre/article_attachment.json
@@ -1,9 +1,15 @@
 {
   "id":           1428,
+  "url": "https://company.zendesk.com/api/v2/help_center/articles/attachments/200109629",
   "article_id":   23,
+  "display_file_name": "drawing.png",
   "file_name":    "drawing.png",
   "content_url":  "https://company.zendesk.com/hc/article_attachments/200109629/drawing.png",
+  "relative_path": "/hc/article_attachments/200109629/drawing.png",
   "content_type": "image/png",
   "size":         58298,
-  "inline":       true
+  "inline":       true,
+  "created_at": "2019-03-01T22:18:23Z",
+  "updated_at": "2019-03-01T22:19:19Z",
+  "legacy": true
 }

--- a/zenpy/lib/api.py
+++ b/zenpy/lib/api.py
@@ -853,7 +853,7 @@ class AttachmentApi(Api):
         :param fp: file object, StringIO instance, content, or file path to be
                    uploaded
         :param token: upload token for uploading multiple files
-        :param target_name: name of the file inside¡ Zendesk
+        :param target_name: name of the file inside Zendesk
         :return: :class:`Upload` object containing a token and other information see
             Zendesk API `Reference <https://developer.zendesk.com/rest_api/docs/core/attachments#uploading-files>`__.
         """
@@ -1821,14 +1821,36 @@ class SectionApi(HelpCentreApiBase, CRUDApi, TranslationApi, SubscriptionApi, Ac
 class ArticleAttachmentApi(HelpCentreApiBase, SubscriptionApi):
     @extract_id(Article)
     def __call__(self, article):
+        """
+        Returns all attachments associated with article_id either ``inline=True`` or ``inline=False``.
+
+        :param article: Numeric article id or :class:`Article` object.
+        :return: Generator with all associated articles attachments.
+        """
         return self._query_zendesk(self.endpoint, 'article_attachment', id=article)
 
     @extract_id(Article)
     def inline(self, article):
+        """
+        Returns all inline attachments associated with article_id where (Such attachments has ``inline=True`` flag).
+
+        Inline attachments and its url can be referenced in the HTML body of the article.
+
+        :param article: Numeric article id or :class:`Article` object.
+        :return: Generator with all associated inline attachments.
+        """
         return self._query_zendesk(self.endpoint.inline, 'article_attachment', id=article)
 
     @extract_id(Article)
     def block(self, article):
+        """
+        Returns all block attachments associated with article_id (Such attachments has ``inline=False``).
+
+        Block attachments are displayed as separated files attached to Article.
+
+        :param article: Numeric article id or :class:`Article` object.
+        :return: Generator with all associated block attachments.
+        """
         return self._query_zendesk(self.endpoint.block, 'article_attachment', id=article)
 
     @extract_id(ArticleAttachment)
@@ -1836,7 +1858,20 @@ class ArticleAttachmentApi(HelpCentreApiBase, SubscriptionApi):
         return self._query_zendesk(self.endpoint, 'article_attachment', id=attachment)
 
     @extract_id(Article)
-    def create(self, article, attachment, inline=False, file_name=None, content_type = None):
+    def create(self, article, attachment, inline=False, file_name=None, content_type=None):
+        """
+        This function creates attachment attached to article.
+
+        :param article: Numeric article id or :class:`Article` object.
+        :param attachment: File object or os path to file
+        :param inline: If true, the attached file is shown in the dedicated admin UI
+            for inline attachments and its url can be referenced in the HTML body of
+            the article. If false, the attachment is listed in the list of attachments.
+            Default is `false`
+        :param file_name: you can set filename on file upload.
+        :param content_type: The content type of the file. `Example: image/png`, Zendesk can ignore it.
+        :return: :class:`ArticleAttachment` object
+        """
         return HelpdeskAttachmentRequest(self).post(self.endpoint.create,
                                                     article=article,
                                                     attachment=attachment,
@@ -1844,13 +1879,36 @@ class ArticleAttachmentApi(HelpCentreApiBase, SubscriptionApi):
                                                     file_name=file_name,
                                                     content_type=content_type)
 
-    def create_unassociated(self, attachment, inline=False):
+    def create_unassociated(self, attachment, inline=False, file_name=None, content_type=None):
+        """
+        You can use this endpoint for bulk imports.
+        It lets you upload a file without associating it to an article until later.
+        Check Zendesk documentation `important notes
+        <https://developer.zendesk.com/rest_api/docs/help_center/article_attachments#create-unassociated-attachment>
+
+        :param attachment: File object or os path to file
+        :param inline: If true, the attached file is shown in the dedicated admin UI
+            for inline attachments and its url can be referenced in the HTML body of
+            the article. If false, the attachment is listed in the list of attachments.
+            Default is `false`
+        :param file_name: you can set filename on file upload.
+        :param content_type: The content type of the file. `Example: image/png`, Zendesk can ignore it.
+        :return: :class:`ArticleAttachment` object
+        """
         return HelpdeskAttachmentRequest(self).post(self.endpoint.create_unassociated,
                                                     attachment=attachment,
-                                                    inline=inline)
+                                                    inline=inline,
+                                                    file_name=file_name,
+                                                    content_type=content_type)
 
     @extract_id(ArticleAttachment)
     def delete(self, article_attachment):
+        """
+        This function completely wipes attachment from Zendesk Helpdesk article.
+
+        :param article_attachment: :class:`ArticleAttachment` object or numeric article attachment id.
+        :return: status_code == 204 on success
+        """
         return HelpdeskAttachmentRequest(self).delete(self.endpoint.delete, article_attachment)
 
 

--- a/zenpy/lib/api_objects/help_centre_objects.py
+++ b/zenpy/lib/api_objects/help_centre_objects.py
@@ -296,10 +296,16 @@ class ArticleAttachment(BaseObject):
                  article_id=None,
                  content_type=None,
                  content_url=None,
+                 created_at=None,
+                 display_file_name=None,
                  file_name=None,
                  id=None,
                  inline=None,
+                 legacy=None,
+                 relative_path=None,
                  size=None,
+                 updated_at=None,
+                 url=None,
                  **kwargs):
 
         self.api = api
@@ -316,6 +322,11 @@ class ArticleAttachment(BaseObject):
         # Type: string
         self.content_url = content_url
 
+        # Comment: The time at which the article attachment was created
+        # Type: timestamp
+        self.created_at = created_at
+        self.display_file_name = display_file_name
+
         # Comment: The name of the file
         # Type: string
         self.file_name = file_name
@@ -327,10 +338,20 @@ class ArticleAttachment(BaseObject):
         # Comment: If true, the attached file is shown in the dedicated admin UI for inline attachments and its url can be referenced in the HTML body of the article. If false, the attachment is listed in the list of attachments. Default is false
         # Type: boolean
         self.inline = inline
+        self.legacy = legacy
+        self.relative_path = relative_path
 
         # Comment: The size of the attachment file in bytes
         # Type: integer
         self.size = size
+
+        # Comment: The time at which the article attachment was last updated
+        # Type: timestamp
+        self.updated_at = updated_at
+
+        # Comment: The API url of this article attachment
+        # Type: string
+        self.url = url
 
         for key, value in kwargs.items():
             setattr(self, key, value)
@@ -355,6 +376,32 @@ class ArticleAttachment(BaseObject):
         if article:
             self.article_id = article.id
             self._article = article
+
+    @property
+    def created(self):
+        """
+        |  Comment: The time at which the article attachment was created
+        """
+        if self.created_at:
+            return dateutil.parser.parse(self.created_at)
+
+    @created.setter
+    def created(self, created):
+        if created:
+            self.created_at = created
+
+    @property
+    def updated(self):
+        """
+        |  Comment: The time at which the article attachment was last updated
+        """
+        if self.updated_at:
+            return dateutil.parser.parse(self.updated_at)
+
+    @updated.setter
+    def updated(self, updated):
+        if updated:
+            self.updated_at = updated
 
 
 class Category(BaseObject):

--- a/zenpy/lib/request.py
+++ b/zenpy/lib/request.py
@@ -510,16 +510,24 @@ class HelpdeskAttachmentRequest(BaseZendeskRequest):
         else:
             url = self.api._build_url(endpoint())
 
-        use_file_name = bool(file_name) and bool(content_type)
-        if (bool(file_name) or bool(content_type)) and not use_file_name:
-            raise ZenpyException("Content_type and file_name are expected together!")
-
         if hasattr(attachment, 'read'):
-            file = attachment if not use_file_name else (file_name, attachment, content_type)
-            return self.api._post(url, payload={}, files=dict(inline=(None, inline), file=file))
+            file = (file_name if file_name else attachment.name, attachment, content_type)
+            return self.api._post(url,
+                                      payload={},
+                                      files=dict(
+                                                 inline=(None, 'true' if inline else 'false'),
+                                                 file=file
+                                                 )
+                                      )
         elif os.path.isfile(attachment):
             with open(attachment, 'rb') as fp:
-                file = fp if not use_file_name else (file_name, fp, content_type)
-                return self.api._post(url, payload={}, files=dict(inline=(None, inline), file=file))
+                file = (file_name if file_name else fp.name, fp, content_type)
+                return self.api._post(url,
+                                      payload={},
+                                      files=dict(
+                                                 inline=(None, 'true' if inline else 'false'),
+                                                 file=file
+                                                 )
+                                      )
 
         raise ValueError("Attachment is not a file-like object or valid path!")


### PR DESCRIPTION
Fix and document on ArticleAttachments endpoint.

* Request does not understand Bool values as input in files mode
* Allowing changing names without setting content type.
* Allowing setting content type without setting name.

PR Fix #292
Closes #306 