### PR TITLE
Add support for `include_inline_images` param when listing Comments

### DIFF
--- a/zenpy/lib/api.py
+++ b/zenpy/lib/api.py
@@ -1042,8 +1042,8 @@ class TicketApi(RateableApi, TaggableApi, IncrementalApi, CRUDApi):
         Retrieve the comments for a ticket.
 
         :param ticket: Ticket object or id
-        :param include_inline_images: inline image attachments will be included
-            in each comments' `attachment` field.
+        :param include_inline_images: Boolean. If `True`, inline image attachments will be
+            returned in each comments' `attachments` field alongside non-inline attachments
         """
         return self._query_zendesk(
             self.endpoint.comments, 'comment', id=ticket,

--- a/zenpy/lib/api.py
+++ b/zenpy/lib/api.py
@@ -1037,13 +1037,18 @@ class TicketApi(RateableApi, TaggableApi, IncrementalApi, CRUDApi):
         return self._query_zendesk(self.endpoint.recent, 'ticket', id=None, include=include)
 
     @extract_id(Ticket)
-    def comments(self, ticket):
+    def comments(self, ticket, include_inline_images=None):
         """
         Retrieve the comments for a ticket.
 
         :param ticket: Ticket object or id
+        :param include_inline_images: inline image attachments will be included
+            in each comments' `attachment` field.
         """
-        return self._query_zendesk(self.endpoint.comments, 'comment', id=ticket)
+        return self._query_zendesk(
+            self.endpoint.comments, 'comment', id=ticket,
+            include_inline_images=include_inline_images
+        )
 
     def permanently_delete(self, tickets):
         """

--- a/zenpy/lib/endpoint.py
+++ b/zenpy/lib/endpoint.py
@@ -138,8 +138,22 @@ class PrimaryEndpoint(BaseEndpoint):
 
 
 class SecondaryEndpoint(BaseEndpoint):
-    def __call__(self, id, include=None):
-        return Url(self.endpoint % dict(id=id), params=dict(include=include) if include else None)
+    def __call__(self, id, **kwargs):
+        parameters = {}
+        for key, value in kwargs.items():
+            if key == 'include':
+                if is_iterable_but_not_string(value):
+                    parameters[key] = ",".join(value)
+                elif value:
+                    parameters[key] = value
+
+            elif key == 'include_inline_images':
+                if value:
+                    parameters[key] = 'true'
+        return Url(
+            self.endpoint % dict(id=id),
+            params=(parameters or None)
+        )
 
 
 class MultipleIDEndpoint(BaseEndpoint):


### PR DESCRIPTION
@facetoe - thanks for your efforts on this lib, it's been a useful wrapper for several projects for me now. :)

I needed to add support for the query parameter `include_inline_images` when listing comments, in order to get the full lists of their attachments: https://developer.zendesk.com/rest_api/docs/support/attachments

To achieve this, in `SecondaryEndpoint`, I updated the way parameters are built up to be more similar to how it's done for `PrimaryEndpoint`. So now the following works as expected:

```python
comments = client.tickets.comments(ticket, include_inline_images=True)
```

I didn't find a suitable place for this to be added to the docs - I think people will find the param in Zendesk's docs and then find Zenpy supports it.

Let me know if there are any changes you'd like me to make to this PR.
