### PR TITLE
Multiple job statuses support

### DIFF
--- a/zenpy/lib/api.py
+++ b/zenpy/lib/api.py
@@ -78,6 +78,7 @@ class BaseApi(object):
             DeleteResponseHandler,
             TagResponseHandler,
             SearchResponseHandler,
+            JobStatusesResponseHandler,
             CombinationResponseHandler,
             ViewResponseHandler,
             SlaPolicyResponseHandler,

--- a/zenpy/lib/response.py
+++ b/zenpy/lib/response.py
@@ -232,6 +232,26 @@ class CombinationResponseHandler(GenericZendeskResponseHandler):
             return zenpy_objects['ticket_audit']
         raise ZenpyException("Could not process response: {}".format(response))
 
+class JobStatusesResponseHandler(GenericZendeskResponseHandler):
+
+    @staticmethod
+    def applies_to(api, response):
+        try:
+            response_json = response.json()
+            if 'job_statuses' in response_json:
+                return True
+        except ValueError:
+            return False
+
+    def build(self, response):
+        response_objects = {'job_statuses': []}
+        for object_json in response.json()['job_statuses']:
+            zenpy_object = self.object_mapping.object_from_json(
+                'job_status',
+                object_json
+            )
+            response_objects['job_statuses'].append(zenpy_object)
+        return response_objects
 
 class TagResponseHandler(ResponseHandler):
     """ Tags aint complicated, just return them. """


### PR DESCRIPTION
Added multiple job statuses parsing for a call like 

`job_ids = [...]`
`job_statuses = zenpy_client.job_status(ids=job_ids)`

Now it returns a collection under a key 'job_statuses'