### PR TITLE
Search count

### DIFF
--- a/zenpy/__init__.py
+++ b/zenpy/__init__.py
@@ -33,7 +33,9 @@ from zenpy.lib.api import (
     TicketFormApi,
     OrganizationFieldsApi,
     JiraLinkApi, SkipApi, TalkApi,
-    CustomAgentRolesApi)
+    CustomAgentRolesApi,
+    SearchApi)
+
 from zenpy.lib.cache import ZenpyCache, ZenpyCacheManager
 from zenpy.lib.endpoint import EndpointFactory
 from zenpy.lib.exception import ZenpyException
@@ -109,7 +111,7 @@ class Zenpy(object):
         self.organization_fields = OrganizationFieldsApi(config)
         self.tickets = TicketApi(config)
         self.suspended_tickets = SuspendedTicketApi(config, object_type='suspended_ticket')
-        self.search = Api(config, object_type='results', endpoint=EndpointFactory('search'))
+        self.search = SearchApi(config)
         self.topics = Api(config, object_type='topic')
         self.attachments = AttachmentApi(config)
         self.brands = BrandApi(config, object_type='brand')

--- a/zenpy/lib/api.py
+++ b/zenpy/lib/api.py
@@ -76,6 +76,7 @@ class BaseApi(object):
         }
         self.ratelimit_request_interval = ratelimit_request_interval
         self._response_handlers = (
+            CountResponseHandler,
             DeleteResponseHandler,
             TagResponseHandler,
             SearchResponseHandler,
@@ -2154,3 +2155,19 @@ class PhoneNumbersApi(TalkApiBase):
 
 class CustomAgentRolesApi(CRUDApi):
     pass
+
+class SearchApi(BaseApi):
+    def __init__(self, config):
+        self.object_type = 'results'
+        self.endpoint = EndpointFactory('search')
+        super(SearchApi, self).__init__(**config)
+        self._object_mapping = ZendeskObjectMapping(self)
+
+    def __call__(self, *args, **kwargs):
+        return self._query_zendesk(self.endpoint, self.object_type, *args, **kwargs)
+
+    def count(self, *args, **kwargs):
+        """
+        Returns results count only
+        """
+        return self._query_zendesk(self.endpoint.count, 'search_count', *args, **kwargs)

--- a/zenpy/lib/endpoint.py
+++ b/zenpy/lib/endpoint.py
@@ -499,6 +499,7 @@ class EndpointFactory(object):
     satisfaction_ratings.create = SecondaryEndpoint('tickets/%(id)s/satisfaction_rating.json')
     schedules = PrimaryEndpoint('business_hours/schedules')
     search = SearchEndpoint('search.json')
+    search.count = SearchEndpoint('search/count.json')
     sharing_agreements = PrimaryEndpoint('sharing_agreements')
     sla_policies = PrimaryEndpoint('slas/policies')
     sla_policies.definitions = PrimaryEndpoint('slas/policies/definitions')

--- a/zenpy/lib/response.py
+++ b/zenpy/lib/response.py
@@ -205,13 +205,13 @@ class SearchResponseHandler(GenericZendeskResponseHandler):
         return SearchResultGenerator(self, response.json())
 
 class CountResponseHandler(GenericZendeskResponseHandler):
-    """ Handles Zendesk search results. """
+    """ Handles Zendesk search results counts. """
 
     @staticmethod
     def applies_to(api, response):
         try:
             response_json = response.json()
-            return len(response_json) == 1 and 'count' in response.json()
+            return len(response_json) == 1 and 'count' in response_json
         except ValueError:
             return False
 

--- a/zenpy/lib/response.py
+++ b/zenpy/lib/response.py
@@ -204,6 +204,20 @@ class SearchResponseHandler(GenericZendeskResponseHandler):
     def build(self, response):
         return SearchResultGenerator(self, response.json())
 
+class CountResponseHandler(GenericZendeskResponseHandler):
+    """ Handles Zendesk search results. """
+
+    @staticmethod
+    def applies_to(api, response):
+        try:
+            response_json = response.json()
+            return len(response_json) == 1 and 'count' in response.json()
+        except ValueError:
+            return False
+
+    def build(self, response):
+        return response.json()['count']
+
 
 class CombinationResponseHandler(GenericZendeskResponseHandler):
     """ Handles a few special cases where the return type is made up of two objects. """


### PR DESCRIPTION
Added **zenpy.search.count(**) which takes all the same as **zenpy.search()** but returns count only.

Documentation: https://developer.zendesk.com/rest_api/docs/support/search#show-results-count

Usual **zenpy.search()** should not be affected, I hope :)

I need this functionality after last [changes to searching limits](https://developer.zendesk.com/rest_api/docs/support/search#results-limit).

