### PR TITLE
Support for Jira Links API pagination and deserialization

### DIFF
--- a/zenpy/lib/api.py
+++ b/zenpy/lib/api.py
@@ -305,7 +305,7 @@ class BaseApi(object):
             except ValueError:
                 response.raise_for_status()
 
-    def _build_url(self, endpoint):
+    def _build_url(self, endpoint, api_prefix=None):
         """ Build complete URL """
         if not issubclass(type(self), ChatApiBase) and not self.subdomain:
             raise ZenpyException("subdomain is required when accessing the Zendesk API!")
@@ -315,7 +315,7 @@ class BaseApi(object):
         else:
             endpoint.netloc = self.domain
 
-        endpoint.prefix_path(self.api_prefix)
+        endpoint.prefix_path(api_prefix or self.api_prefix)
         return endpoint.build()
 
 
@@ -1630,6 +1630,12 @@ class JiraLinkApi(CRUDApi):
 
     def update(self, api_objects, **kwargs):
         raise ZenpyException("Cannot update Jira Links!")
+
+    def _build_url(self, endpoint):
+        if not endpoint.path == 'services/jira/links.json':
+            return super(JiraLinkApi, self)._build_url(endpoint, 'api/v2')
+        else:
+            return super(JiraLinkApi, self)._build_url(endpoint)
 
 
 class SlaPolicyApi(CRUDApi):

--- a/zenpy/lib/generator.py
+++ b/zenpy/lib/generator.py
@@ -227,6 +227,24 @@ class TicketAuditGenerator(ZendeskResultGenerator):
         return iter(self)
 
 
+class JiraLinkGenerator(ZendeskResultGenerator):
+    def __init__(self, response_handler, response_json):
+        super(JiraLinkGenerator, self).__init__(response_handler, response_json,
+                                                   response_objects=None,
+                                                   object_type='links')
+        self.next_page_attr = 'since_id'
+
+    def get_next_page(self, page_num=None, page_size=None):
+        try:
+            url = self._response_json['links'][-1]['url']
+            url = re.sub('/\d+', '', url)
+            params = {'since_id': self._response_json['links'][-1]['id']}
+            response = self.response_handler.api._get(url, raw_response=True, params=params)
+            return response.json()
+        except (IndexError, KeyError):
+            raise StopIteration()
+
+
 class ChatResultGenerator(BaseResultGenerator):
     """
     Generator for ChatApi objects

--- a/zenpy/lib/response.py
+++ b/zenpy/lib/response.py
@@ -2,7 +2,7 @@ from abc import abstractmethod
 
 from zenpy.lib.exception import ZenpyException
 from zenpy.lib.generator import SearchResultGenerator, ZendeskResultGenerator, ChatResultGenerator, ViewResultGenerator, \
-    TicketAuditGenerator, ChatIncrementalResultGenerator
+    TicketAuditGenerator, ChatIncrementalResultGenerator, JiraLinkGenerator
 from zenpy.lib.util import as_singular, as_plural, get_endpoint_path
 
 
@@ -99,6 +99,10 @@ class GenericZendeskResponseHandler(ResponseHandler):
         # Special case for ticket audits.
         if get_endpoint_path(self.api, response).startswith('/ticket_audits.json'):
             return TicketAuditGenerator(self, response_json)
+
+        # Special case for Jira links.
+        if get_endpoint_path(self.api, response).startswith('/services/jira/links'):
+            return JiraLinkGenerator(self, response_json)
 
         zenpy_objects = self.deserialize(response_json)
 


### PR DESCRIPTION
This PR has one enhancement and one fix.

I added a generator for Jira links using 'since_id' so we can paginate through all of the results. This should address https://github.com/facetoe/zenpy/issues/359.

I also fixed an issue where referencing a ticket from a Jira link would always fail. This was because it would build the API URL using the prefix for Jira links, 'api', instead of the prefix for tickets, 'api/v2'.