### PR TITLE
close #391, introduce ZENPY_FORCE_NETLOC and ZENPY_FORCE_SCHEME

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,27 @@ user.remote_photo_url = 'http://domain/example_photo.jpg'
 zenpy_client.users.update(user)
 ```
 
+## Environment variables
+
+By default zenpy will make request to
+
+```
+https://{subdomain}.{domain}/{endpoint}
+```
+
+(with domain being by default `zendesk.com`), in some cases you may want to override this behaviour
+(like for local testing or if you have a custom domain for zendesk)
+You can do this by setting the environment variables
+
+  * `ZENPY_FORCE_NETLOC`
+  * `ZENPY_FORCE_SCHEME` (default to https)
+
+when set it will force request on
+
+```
+{scheme}://{netloc}/endpoint
+```
+
 ## Documentation
 
 Check out the [documentation](http://docs.facetoe.com.au/) for more info.

--- a/zenpy/lib/api.py
+++ b/zenpy/lib/api.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 
+import os
 import json
 import logging
 from time import sleep, time
@@ -58,6 +59,9 @@ class BaseApi(object):
     Base class for API. Responsible for submitting requests to Zendesk, controlling
     rate limiting and deserializing responses.
     """
+
+    forced_netloc = os.environ.get("ZENPY_FORCE_NETLOC")
+    forced_scheme = os.environ.get("ZENPY_FORCE_SCHEME", "https")
 
     def __init__(self,
                  subdomain,
@@ -313,7 +317,10 @@ class BaseApi(object):
         if not issubclass(type(self), ChatApiBase) and not self.subdomain:
             raise ZenpyException("subdomain is required when accessing the Zendesk API!")
 
-        if self.subdomain:
+        if self.forced_netloc is not None:
+            endpoint.netloc = self.forced_netloc
+            endpoint.scheme = self.forced_scheme
+        elif self.subdomain:
             endpoint.netloc = '{}.{}'.format(self.subdomain, self.domain)
         else:
             endpoint.netloc = self.domain

--- a/zenpy/lib/response.py
+++ b/zenpy/lib/response.py
@@ -46,6 +46,9 @@ class GenericZendeskResponseHandler(ResponseHandler):
     @staticmethod
     def applies_to(api, response):
         try:
+            if api.forced_netloc is not None:
+                return api.forced_netloc in response.request.url and response.json()
+
             return api.domain in response.request.url and response.json()
         except ValueError:
             return False


### PR DESCRIPTION
to permit more advanced control on the generated url for zendesk api call