### PR TITLE
Replace future with six

### DIFF
--- a/requirements.dev
+++ b/requirements.dev
@@ -1,7 +1,6 @@
 cachetools>=3.1.0
 requests>=2.14.2
 pytz>=2018.9
-future>=0.17.1
 python-dateutil>=2.7.5
 sphinx>=1.8.4
 pycodestyle>=2.5.0
@@ -13,3 +12,4 @@ yapf>=0.26.0
 bs4>=0.0.1
 lxml>=4.3.1
 sphinx_rtd_theme>=0.4.3
+six>=1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cachetools>=3.1.0
 requests>=2.14.2
 pytz>=2018.9
-future>=0.17.1
 python-dateutil>=2.7.5
+six>=1.14.0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         'python-dateutil>=2.7.5',
         'cachetools>=3.1.0',
         'pytz>=2018.9',
-        'future>=0.17.1'
+        'six>=1.14.0',
     ],
     keywords=['zendesk', 'api', 'wrapper'],
     classifiers=[

--- a/zenpy/lib/generator.py
+++ b/zenpy/lib/generator.py
@@ -5,8 +5,6 @@ import re
 from abc import abstractmethod
 from datetime import datetime, timedelta
 
-from future.standard_library import install_aliases
-
 from zenpy.lib.util import as_plural
 from zenpy.lib.exception import SearchResponseLimitExceeded
 
@@ -15,7 +13,7 @@ try:
 except ImportError:
     from collections import Iterable
 
-install_aliases()
+import six
 from math import ceil
 
 __author__ = 'facetoe'
@@ -124,6 +122,10 @@ class BaseResultGenerator(Iterable):
         # Calculate our range of pages.
         min_page = ceil(start / page_size)
         max_page = ceil(stop / page_size) + 1
+
+        if six.PY2:
+            min_page = int(min_page)
+            max_page = int(max_page)
 
         # Calculate the lower and upper bounds for the final slice.
         padding = ((max_page - min_page) - 1) * page_size

--- a/zenpy/lib/response.py
+++ b/zenpy/lib/response.py
@@ -4,7 +4,7 @@ from zenpy.lib.exception import ZenpyException
 from zenpy.lib.generator import SearchResultGenerator, ZendeskResultGenerator, ChatResultGenerator, ViewResultGenerator, \
     TicketAuditGenerator, ChatIncrementalResultGenerator, JiraLinkGenerator
 from zenpy.lib.util import as_singular, as_plural, get_endpoint_path
-from urllib.parse import urlparse
+from six.moves.urllib.parse import urlparse
 
 
 class ResponseHandler(object):


### PR DESCRIPTION
This closes #402 by changing `future` with `six` as dependency to support Python 2 and 3.

I added an explicit cast to integer for the `ceil()` function only if running on Python 2, this makes easier to remove the code in a future when the package drops support for this version.

This was tested on Python 2.7 and from 3.5 to 3.8.