### PR TITLE
Support for filtering in the Jira Link generator.

### DIFF
--- a/zenpy/lib/generator.py
+++ b/zenpy/lib/generator.py
@@ -238,7 +238,8 @@ class TicketAuditGenerator(ZendeskResultGenerator):
 
 
 class JiraLinkGenerator(ZendeskResultGenerator):
-    def __init__(self, response_handler, response_json):
+    def __init__(self, response_handler, response_json, response=None):
+        self.response = response
         super(JiraLinkGenerator, self).__init__(response_handler, response_json,
                                                    response_objects=None,
                                                    object_type='links')

--- a/zenpy/lib/response.py
+++ b/zenpy/lib/response.py
@@ -103,7 +103,7 @@ class GenericZendeskResponseHandler(ResponseHandler):
 
         # Special case for Jira links.
         if get_endpoint_path(self.api, response).startswith('/services/jira/links'):
-            return JiraLinkGenerator(self, response_json)
+            return JiraLinkGenerator(self, response_json, response)
 
         zenpy_objects = self.deserialize(response_json)
 


### PR DESCRIPTION
As was pointed out by @mvforgione in #400 the Jira Link generator I added in #389 did not respect `ticket_id` or `issue_id` filtering.

This change adds support for filtering by passing the raw requests response on initialization of `JiraLinkGenerator`. Using the requests response `get_next_page` is able to persist any filtering from the original requests.