### PR TITLE
Adds user search

### DIFF
--- a/tests/test_api/test_user_search_api.py
+++ b/tests/test_api/test_user_search_api.py
@@ -1,0 +1,17 @@
+from unittest import TestCase
+
+from zenpy.lib.api import UserSearchApi
+from zenpy.lib.exception import ZenpyException
+from tests.test_api import configure
+
+
+class TestUserSearchApi(TestCase):
+    def test_raises_zenpyexception_when_neither_query_nor_external_id_are_set(self):
+        client, _ = configure()
+        with self.assertRaises(ZenpyException):
+            client.users.search()
+
+    def test_raises_zenpyexception_when_both_query_and_external_id_are_set(self):
+        client, _ = configure()
+        with self.assertRaises(ZenpyException):
+            client.users.search(query=1, external_id=2)

--- a/zenpy/lib/api.py
+++ b/zenpy/lib/api.py
@@ -589,7 +589,7 @@ class IncrementalApi(Api):
         """
         Retrieve bulk data from the incremental API.
 
-        :param include: list of objects to sideload. `Side-loading API Docs 
+        :param include: list of objects to sideload. `Side-loading API Docs
             <https://developer.zendesk.com/rest_api/docs/core/side_loading>`__.
         :param start_time: The time of the oldest object you are interested in.
         """
@@ -705,6 +705,29 @@ class UserIdentityApi(Api):
         return UserIdentityRequest(self).delete(user, identity)
 
 
+class UserSearchApi(Api):
+    def __init__(self, config):
+        super(UserSearchApi, self).__init__(config,
+                                              object_type='user',
+                                              endpoint=EndpointFactory('users').search)
+
+    def __call__(self, query=None, external_id=None):
+        try:
+            assert query or external_id
+            assert not (query and external_id)
+        except AssertionError:
+            raise ZenpyException(
+                "Must provide either `query` or `external_id` arg to search. Not Both."
+            )
+
+        if query:
+            params = dict(query=query)
+        if external_id:
+            params = dict(external_id=external_id)
+        url = self._build_url(self.endpoint())
+        return self._get(url, params=params)
+
+
 class UserApi(IncrementalApi, CRUDExternalApi, TaggableApi):
     """
     The UserApi adds some User specific functionality
@@ -713,13 +736,14 @@ class UserApi(IncrementalApi, CRUDExternalApi, TaggableApi):
     def __init__(self, config):
         super(UserApi, self).__init__(config, object_type='user')
         self.identities = UserIdentityApi(config)
+        self.search = UserSearchApi(config)
 
     @extract_id(User)
     def groups(self, user, include=None):
         """
         Retrieve the groups for this user.
 
-        :param include: list of objects to sideload. `Side-loading API Docs 
+        :param include: list of objects to sideload. `Side-loading API Docs
             <https://developer.zendesk.com/rest_api/docs/core/side_loading>`__.
         :param user: User object or id
         """
@@ -730,7 +754,7 @@ class UserApi(IncrementalApi, CRUDExternalApi, TaggableApi):
         """
         Retrieve the organizations for this user.
 
-        :param include: list of objects to sideload. `Side-loading API Docs 
+        :param include: list of objects to sideload. `Side-loading API Docs
             <https://developer.zendesk.com/rest_api/docs/core/side_loading>`__.
         :param user: User object or id
         """
@@ -741,7 +765,7 @@ class UserApi(IncrementalApi, CRUDExternalApi, TaggableApi):
         """
         Retrieve the requested tickets for this user.
 
-        :param include: list of objects to sideload. `Side-loading API Docs 
+        :param include: list of objects to sideload. `Side-loading API Docs
             <https://developer.zendesk.com/rest_api/docs/core/side_loading>`__.
         :param user: User object or id
         """
@@ -752,7 +776,7 @@ class UserApi(IncrementalApi, CRUDExternalApi, TaggableApi):
         """
         Retrieve the tickets this user is cc'd into.
 
-        :param include: list of objects to sideload. `Side-loading API Docs 
+        :param include: list of objects to sideload. `Side-loading API Docs
             <https://developer.zendesk.com/rest_api/docs/core/side_loading>`__.
         :param user: User object or id
         """
@@ -763,7 +787,7 @@ class UserApi(IncrementalApi, CRUDExternalApi, TaggableApi):
         """
         Retrieve the assigned tickets for this user.
 
-        :param include: list of objects to sideload. `Side-loading API Docs 
+        :param include: list of objects to sideload. `Side-loading API Docs
             <https://developer.zendesk.com/rest_api/docs/core/side_loading>`__.
         :param user: User object or id
         """
@@ -774,7 +798,7 @@ class UserApi(IncrementalApi, CRUDExternalApi, TaggableApi):
         """
         Retrieve the group memberships for this user.
 
-        :param include: list of objects to sideload. `Side-loading API Docs 
+        :param include: list of objects to sideload. `Side-loading API Docs
             <https://developer.zendesk.com/rest_api/docs/core/side_loading>`__.
         :param user: User object or id
         """
@@ -797,7 +821,7 @@ class UserApi(IncrementalApi, CRUDExternalApi, TaggableApi):
         """
         Return the logged in user
 
-        :param include: list of objects to sideload. `Side-loading API Docs 
+        :param include: list of objects to sideload. `Side-loading API Docs
             <https://developer.zendesk.com/rest_api/docs/core/side_loading#abilities>`__.
         """
         return self._query_zendesk(self.endpoint.me, 'user', include=include)
@@ -987,7 +1011,7 @@ class OrganizationApi(TaggableApi, IncrementalApi, CRUDExternalApi):
         """
         Locate an Organization by it's external_id attribute.
 
-        :param include: list of objects to sideload. `Side-loading API Docs 
+        :param include: list of objects to sideload. `Side-loading API Docs
             <https://developer.zendesk.com/rest_api/docs/core/side_loading>`__.
         :param external_id: external id of organization
         """
@@ -1149,7 +1173,7 @@ class TicketApi(RateableApi, TaggableApi, IncrementalApi, CRUDApi):
         """
         Retrieve TicketEvents
 
-        :param include: list of objects to sideload. `Side-loading API Docs 
+        :param include: list of objects to sideload. `Side-loading API Docs
             <https://developer.zendesk.com/rest_api/docs/core/side_loading>`__.
         :param start_time: time to retrieve events from.
         """
@@ -1174,7 +1198,7 @@ class TicketApi(RateableApi, TaggableApi, IncrementalApi, CRUDApi):
         See the `Zendesk docs <https://developer.zendesk.com/rest_api/docs/core/ticket_audits#pagination>`__ for
         information on additional parameters.
 
-        :param include: list of objects to sideload. `Side-loading API Docs 
+        :param include: list of objects to sideload. `Side-loading API Docs
             <https://developer.zendesk.com/rest_api/docs/core/side_loading>`__.
         :param ticket: Ticket object or id
         """

--- a/zenpy/lib/api.py
+++ b/zenpy/lib/api.py
@@ -712,6 +712,17 @@ class UserSearchApi(Api):
                                               endpoint=EndpointFactory('users').search)
 
     def __call__(self, query=None, external_id=None):
+        """
+        Exposes:
+            GET /api/v2/users/search.json?query={query}
+            GET /api/v2/users/search.json?external_id={external_id}
+
+        For more info see:
+            https://developer.zendesk.com/rest_api/docs/support/users#search-users
+
+        :param query: str of some user property like email
+        :param external_id: external_id of resource
+        """
         try:
             assert query or external_id
             assert not (query and external_id)

--- a/zenpy/lib/endpoint.py
+++ b/zenpy/lib/endpoint.py
@@ -561,6 +561,7 @@ class EndpointFactory(object):
     users.identities.request_verification = MultipleIDEndpoint('users/{0}/identities/{1}/request_verification.json')
     users.identities.delete = MultipleIDEndpoint('users/{0}/identities/{1}.json')
     users.skips = SecondaryEndpoint('users/%(id)s/skips.json')
+    users.search = PrimaryEndpoint('users/search.json')
     views = PrimaryEndpoint('views')
     views.active = PrimaryEndpoint('views/active')
     views.compact = PrimaryEndpoint('views/compact')


### PR DESCRIPTION
I noticed the following endpoints are not yet supported:

`GET /api/v2/users/search.json?query={query}`
`GET /api/v2/users/search.json?external_id={external_id}`

[more info](https://developer.zendesk.com/rest_api/docs/support/users#search-users)

This PR adds `UserSearchApi` for this purpose. One thing I noticed is that when using the normal search endpoint (i.e. `client.search(email="hello@goodbye.com", type="user")`) users are not immediately searchable. from the [docs](https://developer.zendesk.com/rest_api/docs/support/search):
    
> "Note: It can take up to a few minutes for new tickets, users, and other resources
>     to be indexed for search. If new resources don't appear in your search results, wait
>     a few minutes and try again."

I've found that `/users/search.json` is a more dependable search for users. 

Example:

```Python
# On my system
def test_user_search(word1, word2):
    email1 = f"{word1}@test.com"
    client.users.create(User(email=email1, name=word1, external_id=f"{word1}-123"))
    # /users/search.json
    print(list(client.users.search(query=email1)))

    email2 = f"{word2}@test.com"
    client.users.create(User(email=email2, name=word2, external_id=f"{word2}-123"))
    # /search.json
    print(list(client.search(email=email2, type="user")))

test_user_search("arnold", "dwayne")                                                               
# > [User(id=410946782533)]
# > []
```
