### PR TITLE
Allow subclasses of zenpy objects when checking type

### DIFF
--- a/zenpy/lib/request.py
+++ b/zenpy/lib/request.py
@@ -49,7 +49,7 @@ class BaseZendeskRequest(RequestHandler):
         if not isinstance(zenpy_objects, Iterable):
             zenpy_objects = [zenpy_objects]
         for zenpy_object in zenpy_objects:
-            if type(zenpy_object) is not expected_type:
+            if not isinstance(zenpy_object, expected_type):
                 raise ZenpyException(
                     "Invalid type - expected {} found {}".format(expected_type, type(zenpy_object))
                 )


### PR DESCRIPTION
This maintains the type checking done by `BaseZendeskRequest.check_type` but allows subclasses of `zenpy` objects.