### PR TITLE
Fix bug with infinite loop in incremental generator

### DIFF
--- a/zenpy/lib/generator.py
+++ b/zenpy/lib/generator.py
@@ -197,6 +197,9 @@ class ZendeskResultGenerator(BaseResultGenerator):
             if (datetime.fromtimestamp(int(end_time)) +
                     timedelta(minutes=5)) > datetime.now():
                 raise StopIteration
+        # No more pages to request
+        if self._response_json.get("end_of_stream") is True:
+            raise StopIteration
         return super(ZendeskResultGenerator,
                      self).get_next_page(page_num, page_size)
 


### PR DESCRIPTION
Looks like ZD uses "end_of_stream" not instead of null "next_page".

Closes #451