### PR TITLE
Add ticket cursor generator

### DIFF
--- a/docs/zenpy.rst
+++ b/docs/zenpy.rst
@@ -315,9 +315,9 @@ code will retrieve all tickets created or modified in the last day:
 .. code:: python
 
     yesterday = datetime.datetime.now() - datetime.timedelta(days=1)
-    result_generator = zenpy_client.tickets.incremental(start_time=yesterday)
-    for ticket in result_generator:
-        print ticket.id
+    result_generator = zenpy_client.users.incremental(start_time=yesterday)
+    for user in result_generator:
+        print user.id
 
 The last ``end_time`` value can be retrieved from the generator:
 
@@ -382,6 +382,25 @@ This is supported in :class:`Zenpy` via the reversed() Python method:
     for audit in reversed(zenpy_client.tickets.audits(cursor='fDE1MTc2MjkwNTQuMHx8')):
         print(audit)
 
+Zendesk also uses cursor based pagination for incremental Ticket exports and this is
+recommended over time based pagination for Ticket exports (Zendesk `documentation
+<https://developer.zendesk.com/rest_api/docs/support/incremental_export#cursor-based-incremental-exports>`__).
+
+.. code:: python
+    # pass in a start_time for your initial cursor request
+    yesterday = datetime.datetime.now() - datetime.timedelta(days=1)
+    result_generator = zenpy_client.tickets.incremental(start_time=yesterday, paginate_by_time=False)
+    for ticket in result_generator:
+        print ticket.id
+
+The last ``after_cursor`` value can be retrieved from the generator:
+
+.. code:: python
+
+    print result_generator.after_cursor
+
+Passing this value to a new call as ``zenpy_client.tickets.incremental(cursor=after_cursor, paginate_by_time=False)``
+will return items created or modified since that point in time.
 
 Rate Limiting
 -------------

--- a/zenpy/lib/endpoint.py
+++ b/zenpy/lib/endpoint.py
@@ -587,6 +587,10 @@ class EndpointFactory(object):
     tickets.events = IncrementalEndpoint('incremental/ticket_events.json')
     tickets.incidents = SecondaryEndpoint('tickets/%(id)s/incidents.json')
     tickets.incremental = IncrementalEndpoint('incremental/tickets.json')
+    tickets.incremental.cursor = PrimaryEndpoint(
+        'incremental/tickets/cursor.json')
+    tickets.incremental.cursor_start = IncrementalEndpoint(
+        'incremental/tickets/cursor.json')
     tickets.metrics = SecondaryEndpoint('tickets/%(id)s/metrics.json')
     tickets.metrics.incremental = IncrementalEndpoint(
         'incremental/ticket_metric_events.json')

--- a/zenpy/lib/generator.py
+++ b/zenpy/lib/generator.py
@@ -197,6 +197,9 @@ class ZendeskResultGenerator(BaseResultGenerator):
             if (datetime.fromtimestamp(int(end_time)) +
                     timedelta(minutes=5)) > datetime.now():
                 raise StopIteration
+        # No more pages to request
+        if self._response_json.get("end_of_stream") is True:
+            raise StopIteration
         return super(ZendeskResultGenerator,
                      self).get_next_page(page_num, page_size)
 
@@ -223,16 +226,16 @@ class SearchResultGenerator(BaseResultGenerator):
             raise StopIteration()
 
 
-class TicketAuditGenerator(ZendeskResultGenerator):
-    def __init__(self, response_handler, response_json):
-        super(TicketAuditGenerator, self).__init__(response_handler,
-                                                   response_json,
-                                                   response_objects=None,
-                                                   object_type='audit')
+class TicketCursorGenerator(ZendeskResultGenerator):
+    """
+    Generator for cursor based incremental export endpoints for ticket and ticket_audit objects.
+    """
+    def __init__(self, response_handler, response_json, object_type):
+        super(TicketCursorGenerator, self).__init__(response_handler,
+                                                    response_json,
+                                                    response_objects=None,
+                                                    object_type=object_type)
         self.next_page_attr = 'after_url'
-
-    def get_next_page(self, page_num=None, page_size=None):
-        return super(TicketAuditGenerator, self).get_next_page()
 
     def __reversed__(self):
         # Flip the direction we grab pages.

--- a/zenpy/lib/response.py
+++ b/zenpy/lib/response.py
@@ -2,7 +2,7 @@ from abc import abstractmethod
 
 from zenpy.lib.exception import ZenpyException
 from zenpy.lib.generator import SearchResultGenerator, ZendeskResultGenerator, ChatResultGenerator, ViewResultGenerator, \
-    TicketAuditGenerator, ChatIncrementalResultGenerator, JiraLinkGenerator
+    TicketCursorGenerator, ChatIncrementalResultGenerator, JiraLinkGenerator
 from zenpy.lib.util import as_singular, as_plural, get_endpoint_path
 from six.moves.urllib.parse import urlparse
 
@@ -90,10 +90,20 @@ class GenericZendeskResponseHandler(ResponseHandler):
         """
         response_json = response.json()
 
-        # Special case for ticket audits.
+        # Special case for incremental cursor based ticket audits export.
         if get_endpoint_path(self.api,
                              response).startswith('/ticket_audits.json'):
-            return TicketAuditGenerator(self, response_json)
+            return TicketCursorGenerator(self,
+                                         response_json,
+                                         object_type="audit")
+
+        # Special case for incremental cursor based tickets export.
+        if get_endpoint_path(
+                self.api,
+                response).startswith('/incremental/tickets/cursor.json'):
+            return TicketCursorGenerator(self,
+                                         response_json,
+                                         object_type="ticket")
 
         # Special case for Jira links.
         if get_endpoint_path(self.api,

--- a/zenpy/lib/util.py
+++ b/zenpy/lib/util.py
@@ -139,3 +139,13 @@ def json_encode(obj, serialize):
         return list(obj)
     elif is_iterable_but_not_string(obj):
         return list(obj)
+
+
+def all_are_none(*args) -> bool:
+    """ Check if all args are none. """
+    return all(arg is None for arg in args)
+
+
+def all_are_not_none(*args) -> bool:
+    """ Check if all args are not none. """
+    return all(arg is not None for arg in args)


### PR DESCRIPTION
### Background

- The [Zendesk API](https://developer.zendesk.com/rest_api/docs/support/incremental_export#cursor-based-incremental-exports) has added cursor-based pagination of incremental exports of the _Ticket_ model and recommends using this over time-based pagination for better performance and consistency.

- The _Ticket Audit_ model is the only other model that supports cursor based pagination in the Zendesk API.

- Zenpy implements cursor-based pagination for the _Ticket Audit_ model, but only implements time-based pagination for incremental exports of the _Ticket_ model.

### Changes

- In `zenpy/lib/generator.py`, create the generic `TicketCursorGenerator` subclass to handle cursor based endpoints for `ticket` and `ticket_audit` objects. This generic subclass replaces the `TicketAuditGenerator`.

   - Note that I also have a fix here similar to what you did @facetoe in #455 to check for `end_of_stream` in the response and stop iteration.

- In `zenpy/lib/response.py`, return `TicketCursorGenerator` when handling responses for cursor based endpoints for `ticket` and `ticket_audit` objects.

- In `zenpy/lib/api.py`, override the super class's `IncrementalApi.incremental` method in the subclass `TicketApi`.

   - `TicketApi.incremental` allows use of either time-based pagination or cursor-based pagination.
  
   - To avoid introducing a breaking change, I've defaulted the method to use time-based pagination via the parameter `paginate_by_time=True`. 

   - Let me know if you'd prefer to have this be a breaking change to match the Zendesk API's recommendation to use cursor based pagination.


