### PR TITLE
Added feature to retrieve all ticket fields

### DIFF
--- a/zenpy/lib/api.py
+++ b/zenpy/lib/api.py
@@ -1543,6 +1543,12 @@ class TicketFieldApi(CRUDApi):
     def __init__(self, config):
         super(TicketFieldApi, self).__init__(config, 'ticket_field')
         self.options = TicketCustomFieldOptionApi(config)
+    
+    def all(self):
+        """
+        Retrieve all ticket fields.
+        """
+        return self._query_zendesk(self.endpoint.all, 'ticket_field', id=None)
 
 
 class VariantApi(Api):

--- a/zenpy/lib/endpoint.py
+++ b/zenpy/lib/endpoint.py
@@ -564,6 +564,7 @@ class EndpointFactory(object):
     tags = PrimaryEndpoint('tags')
     targets = PrimaryEndpoint('targets')
     ticket_fields = PrimaryEndpoint('ticket_fields')
+    ticket_fields.all = SecondaryEndpoint('ticket_fields.json')
     ticket_field_options = SecondaryEndpoint(
         'ticket_fields/%(id)s/options.json')
     ticket_field_options.show = MultipleIDEndpoint(


### PR DESCRIPTION
Added method and endpoint to retrieve all ticket fields by calling `ticket_fields.all()`. This can allow users to match up ticket custom fields to the ticket field 'titles'.