### PR TITLE
fix: prevent InvalidEndpoint exception when deleting Jira links

### DIFF
--- a/zenpy/lib/api.py
+++ b/zenpy/lib/api.py
@@ -1836,11 +1836,19 @@ class JiraLinkApi(CRUDApi):
         super(JiraLinkApi, self).__init__(config, object_type='link')
         self.api_prefix = "api"
 
+    def delete(self, link):
+        url = self._build_url(self.endpoint(id=link.id), delete=True)
+        deleted_user = self._delete(url)
+        self.cache.delete(deleted_user)
+        return deleted_user
+
     def update(self, api_objects, **kwargs):
         raise ZenpyException("Cannot update Jira Links!")
 
-    def _build_url(self, endpoint):
-        if not endpoint.path == 'services/jira/links.json':
+    def _build_url(self, endpoint, delete=False):
+        if delete:
+            return super(JiraLinkApi, self)._build_url(endpoint).replace(".json", "")
+        elif not endpoint.path == 'services/jira/links.json':
             return super(JiraLinkApi, self)._build_url(endpoint, 'api/v2')
         else:
             return super(JiraLinkApi, self)._build_url(endpoint)


### PR DESCRIPTION
## Problem

```python
def delete_zendesk_jira_links(zenpy_client, issue):
    for link in zenpy_client.jira_links(issue_id=issue.id):
        zenpy_client.jira_links.delete(link)
```

Returned the following JSON message on valid Jira Links: `{"error":"InvalidEndpoint","description":"Not found"} `

## Solution

Turns out the Delete API for Jira Links is special - you can see more about it [here](https://developer.zendesk.com/api-reference/ticketing/jira/links/#delete-link).

I ended up overwriting the `delete` method in the `JiraLinkAPI` class to compensate for the unique delete URL for this resource.

I didn't find existing tests for `JiraLinkAPI` resources - but could look at creating some if desired in conjunction with this PR.