### PR TITLE
Fix exception message when password and token are provided

### DIFF
--- a/zenpy/__init__.py
+++ b/zenpy/__init__.py
@@ -196,7 +196,7 @@ class Zenpy(object):
                     "password, token or oauth_token are required! {}".format(locals())
                 )
             elif password and token:
-                raise ZenpyException("password and token " "are mutually exclusive!")
+                raise ZenpyException("Password and token are mutually exclusive!")
             if password:
                 session.auth = (email, password)
             elif token:


### PR DESCRIPTION
This is a small fix to the exception message when both `password` and `token` are provided when initializing a `Zenpy` object.