### PR TITLE
zenpy-489 resolve talk calls infinite loop issue

### DIFF
--- a/zenpy/lib/generator.py
+++ b/zenpy/lib/generator.py
@@ -30,8 +30,10 @@ class BaseResultGenerator(Iterable):
     def __init__(self, response_handler, response_json):
         self.response_handler = response_handler
         self._response_json = response_json
+        self.count = response_json.get("count")
         self.values = None
         self.position = 0
+        self._iteration = 0
         self.update_attrs()
         self._has_sliced = False
         self.next_page_attr = 'next_page'
@@ -47,7 +49,10 @@ class BaseResultGenerator(Iterable):
             self.handle_pagination()
         if len(self.values) < 1:
             raise StopIteration()
+        if self.count is not None and self._iteration > self.count:
+            raise StopIteration()
         zenpy_object = self.values[self.position]
+        self._iteration += 1
         self.position += 1
         return zenpy_object
 


### PR DESCRIPTION
## Rationale

The talk incremental export currently gets stuck in an infinite loop when as the next() BaseResultGenerator cannot handle however the Zendesk API is returning the data for talk incremental.

Issue: https://github.com/facetoe/zenpy/issues/489

This PR is to hopefully address that issue.

## Changes

- Added an internal iteration counter to the BaseResultGenerator
- Added a count attribute to BaseResultGenerator which will either be the count of rows returned or None depending on if the API returns the count key.
- Added a check for the iteration counter is greater than the count. If it is then it raises a StopIteration exception and ends the loop.

## Testing

- I have run the tests via the Makefile and everything passes.
<img width="653" alt="image" src="https://user-images.githubusercontent.com/14864200/235582989-3e03a5c8-59a6-4a7e-9061-b1d281c6e54f.png">
- I have manually tested calling the talk API and it now returns my data without getting stuck in a loop.