### PR TITLE
Fixes Issue-571: overly aggressive CBP campaign on single object

### DIFF
--- a/zenpy/lib/api.py
+++ b/zenpy/lib/api.py
@@ -1464,7 +1464,8 @@ class TicketApi(RateableApi, TaggableApi, IncrementalApi, CRUDApi):
         """
         return self._query_zendesk(self.endpoint.metrics,
                                    'ticket_metric',
-                                   id=ticket)
+                                   id=ticket,
+                                   cursor_pagination=False)
 
     def metrics_incremental(self, start_time):
         """


### PR DESCRIPTION
Issue #571 
API endpoint returns single object.
