### PR TITLE
v2.0.51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,18 @@
 - Generating classes now congnizant of execution context to facilitate generation
 
 ### Removed
+
+## [2.0.51] - 2024-09-06
+
+### Added
+- Added method to delete an uploaded attachment from its token id
+- Added method to redact a ticket comment attachment
+- Added tests covering those two actions
+
+### Fixed
+- Fixed issue https://github.com/facetoe/zenpy/issues/350
+
+### Changed
+- README.md (New actions)
+
+### Removed

--- a/pyproject.toml.XXX
+++ b/pyproject.toml.XXX
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zenpy"
-version = "2.0.50"
+version = "2.0.51"
 authors = [
   { name="William Coe", email="facetoe@facetoe.com.au" },
 ]

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (this_directory / "README.md").read_text()
 setup(
     name='zenpy',
     packages=setuptools.find_packages(),
-    version='2.0.50',
+    version='2.0.51',
     description='Python wrapper for the Zendesk API',
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -16,7 +16,7 @@ setup(
     author='Face Toe',
     author_email='facetoe@facetoe.com.au',
     url='https://github.com/facetoe/zenpy',
-    download_url='https://github.com/facetoe/zenpy/releases/tag/2.0.50',
+    download_url='https://github.com/facetoe/zenpy/releases/tag/2.0.51',
     install_requires=[
         'requests>=2.14.2',
         'python-dateutil>=2.7.5',

--- a/zenpy/__init__.py
+++ b/zenpy/__init__.py
@@ -60,7 +60,7 @@ if debug_log is not None:
 log = logging.getLogger()
 
 __author__ = "facetoe"
-__version__ = "2.0.50"
+__version__ = "2.0.51"
 
 
 class Zenpy(object):


### PR DESCRIPTION
## [2.0.51] - 2024-09-06

### Added
- Added method to delete an uploaded attachment from its token id
- Added method to redact a ticket comment attachment
- Added tests covering those two actions

### Fixed
- Fixed issue https://github.com/facetoe/zenpy/issues/350

### Changed
- README.md (New actions)

### Removed