### PR TITLE
Enable listing section articles from all locales includig sideloads

### DIFF
--- a/zenpy/lib/api.py
+++ b/zenpy/lib/api.py
@@ -2432,10 +2432,17 @@ class AccessPolicyApi(Api):
 class SectionApi(HelpCentreApiBase, CRUDApi, TranslationApi, SubscriptionApi,
                  AccessPolicyApi):
     @extract_id(Section)
-    def articles(self, section, locale='en-us'):
-        return self._query_zendesk(self.endpoint.articles,
-                                   'article',
-                                   id=section, locale=locale)
+    def articles(self, section, locale="en-us", include=None):
+        # Set locale to None to search all locales. Not available for anonymous users
+        if not locale:
+            return self._query_zendesk(self.endpoint.articles,
+                                       "article",
+                                       id=section, include=include)
+        else:
+            return self._query_zendesk(self.endpoint.articles,
+                                       "article",
+                                       id=section, locale=locale,
+                                       include=include)
 
     def create(self, section):
         return CRUDRequest(self).post(section,

--- a/zenpy/lib/endpoint.py
+++ b/zenpy/lib/endpoint.py
@@ -172,6 +172,11 @@ class SecondaryEndpoint(BaseEndpoint):
                     parameters['page[size]'] = 100
                 elif value is not False:
                     parameters['page[size]'] = value
+            elif key == "include":
+                if is_iterable_but_not_string(value):
+                    parameters[key] = ",".join(value)
+                elif value:
+                    parameters[key] = value
             else:
                 parameters[key] = value
         return Url(self.endpoint % dict(id=id), params=parameters)


### PR DESCRIPTION
Fixes issue #648 
- Enabled listing articles without the default locale specified
- Enabled sideloading for help_center.sections.articles endpoint
- Enabled parsing sideloads as lists or strings in Secondary endpoints similar to primary endpoints