### PR TITLE
version 2.0.55 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,3 +81,16 @@
 - ZenPy Chat API now going through API v2 and NOT zopim.
 
 ### Removed
+
+## [2.0.55] - 2024-11-08
+
+### Added
+- 
+
+### Fixed
+- Fixed issue https://github.com/facetoe/zenpy/issues/662
+
+### Changed
+- ZenPy JIRA Links API now works on writes and base class supports singular/plural object deserialization.
+
+### Removed

--- a/pyproject.toml.XXX
+++ b/pyproject.toml.XXX
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zenpy"
-version = "2.0.54"
+version = "2.0.55"
 authors = [
   { name="William Coe", email="facetoe@facetoe.com.au" },
 ]

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (this_directory / "README.md").read_text()
 setup(
     name='zenpy',
     packages=setuptools.find_packages(),
-    version='2.0.54',
+    version='2.0.55',
     description='Python wrapper for the Zendesk API',
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -16,7 +16,7 @@ setup(
     author='Face Toe',
     author_email='facetoe@facetoe.com.au',
     url='https://github.com/facetoe/zenpy',
-    download_url='https://github.com/facetoe/zenpy/releases/tag/2.0.54',
+    download_url='https://github.com/facetoe/zenpy/releases/tag/2.0.55',
     install_requires=[
         'requests>=2.14.2',
         'python-dateutil>=2.7.5',

--- a/zenpy/__init__.py
+++ b/zenpy/__init__.py
@@ -60,7 +60,7 @@ if debug_log is not None:
 log = logging.getLogger()
 
 __author__ = "facetoe"
-__version__ = "2.0.54"
+__version__ = "2.0.55"
 
 
 class Zenpy(object):


### PR DESCRIPTION
## [2.0.55] - 2024-11-08

### Added
- 

### Fixed
- Fixed issue https://github.com/facetoe/zenpy/issues/662

### Changed
- ZenPy JIRA Links API now works on writes and base class supports singular/plural object deserialization.

### Removed