### PR TITLE
Omnichannel Engagements APIs

### DIFF
--- a/specification/omnichannel/engagement.json
+++ b/specification/omnichannel/engagement.json
@@ -1,0 +1,22 @@
+{
+    "engagement_id": "dadE#323232",
+    "ticket_id": 2,
+    "agent_id": 212121,
+    "group_id": 1213,
+    "requester_id": 231,
+    "offer_time_seconds": 3,
+    "assignment_to_first_reply_time_seconds": 0,
+    "average_requester_wait_time_seconds": 97,
+    "agent_messages_count": 0,
+    "agent_replies_count": 0,
+    "total_requester_wait_time_seconds": 97,
+    "longest_requester_wait_time_seconds": 97,
+    "channel": "MESSAGING",
+    "engagement_start_reason": "Assigned",
+    "engagement_start_time": "2025-03-31T00:01:57",
+    "engagement_end_time": "2025-03-31T00:03:34",
+    "ticket_status_start": "OPEN",
+    "ticket_status_end": "SOLVED",
+    "engagement_end_reason": "Agent closed conversation",
+    "end_user_messages_count": 0
+}

--- a/tests/test_api/betamax/TestEngagementsApi.test_fetch_engagement_by_id_engagement_id.json
+++ b/tests/test_api/betamax/TestEngagementsApi.test_fetch_engagement_by_id_engagement_id.json
@@ -1,0 +1,86 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2025-06-29T08:13:14",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements/C604EBEFC12F6FFB0B38EEC7F6A8B5EF"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA4ySX0+DMBTF3/cpCM8uaWGUwtuYZTHRmTj/PBICd0gG7aRlizF+d0uZirIle2t6fufce3v7MbEsG3iRFlADV0mZ21Zo2QuCZixi8QI7MYnjCEUuZWzhx2ROI4/F9lXnU2W2hW9PMPMoNdc66yfJJ8TBLg2IS13fqEUj2t1QxTRAgYsCozbw1oJU0BwJSgIfYUIp8olnCLHZaFWVNSQSMsFz2XFuX1nKsuBmECWSTdlIlTSwq95HPBp0WoOU+iSTTLRc/Vc7fzkWlVBplfy2e0hLNaqCUd9XJbjOV5fi2WvKOVRmE3dsvZ4vb1bL/skHq5IqbbrIVApu0LmZHvIzZFfNcA5yvCkiU4QfsRMiJ8TeyAI8P2twQ4/++QA6X7WyL2MMK/ZyCtChRl7f3z6z65M1B+M88S0XB249QC320NPpHhqNX/qQXWIrNXVixZPPLwAAAP//AwCSxcxF/AIAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:14 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "7"
+          ],
+          "x-request-id": [
+            "0f852fb92d152766bef837b5250f9d1d"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements/C604EBEFC12F6FFB0B38EEC7F6A8B5EF"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.9.0"
+}

--- a/tests/test_api/betamax/TestEngagementsApi.test_fetch_engagements.json
+++ b/tests/test_api/betamax/TestEngagementsApi.test_fetch_engagements.json
@@ -1,0 +1,102 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2025-06-28T07:47:28",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA4ySy26DMBBF9/0KxLqRDC4kZEee6qJppXRXVciCCbEKduoxfUX599pOUGmSVmFlzT0z157L9srzfFaC0BmI0hxqeyyYZr439J68rdEN0dF4YRU/mRFKZjQZpGQaj0YTSiZpSsZpOKApoWPiX+87Nc9foO0KDsW94b6WUBrHEY2iKA7IQS+VbDYdPUr6fRrS/uCgK3htADWoDtMn5gtI1M6Qq5XRNa8hQ8ilKNCSYXsDRF4K9yAtsxVXqDMFm+rzpIP8unMNiOaEWS4boU91O4Ofk7XUrMp+Lv7OuD7xig9wJYXx0Jfi+ZoJAZXL5W66XKbz28W8DaATHWqm7FCGUjg4dVuA4k/WOjoyJGHUI3GP3DySZBjEwzA80wSi+K9lcPRTGA/d4N7Ktdw/TBfnGTP5hDgy7r7LZuHllUQoPLOuN1DINDdqG5apmN5LF2zHN2ioM/EbYuc9W9AX8KGzjZ3bKJeGaKrKKWuGWS2VW8yKVQiu6lDkX64cXO2+AQAA//8DAJypaeONAwAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "CF-RAY": [
+            "956b9383d9c13dd5-SIN"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sat, 28 Jun 2025 07:47:28 GMT"
+          ],
+          "NEL": [
+            "{\"success_fraction\":0.01,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+          ],
+          "Report-To": [
+            "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=GrcMwH%2BQy2fY9q%2F0wuwKgAxXUs89jONyuX%2Bw6umO5eG2dY1sgcC6AS7Vr90ccTx0nV02mtlsGo9ukp4f1sjmnl22xO79HFw5RvHdDBrTmShBnyUhWfHAy026mkfPDwDtSWfRtz7lenpdBQiGmaiGKMXpSj%2Fg1AasmQLWIlkuyVCVv6DTFV83SGkpBBq0TjKdvA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+          ],
+          "Server": [
+            "cloudflare"
+          ],
+          "Set-Cookie": [
+            "__cf_bm=EdaiKylUROtqUBR5j4uWgBPVaeqP9CtwjOGezER_Iy8-1751096848-1.0.1.1-oa8T157EJVA15S76JbcVU9bYZeT02vH3aUY5EEA6OUWbmL8iFrliY8apnNC4a.ChOaisXagEIwThNNoQUAn6F7MBnY59bYW7PpQrVIje.So; path=/; expires=Sat, 28-Jun-25 08:17:28 GMT; domain=.d3v-zenpydev.zendesk.com; HttpOnly; Secure; SameSite=None",
+            "_cfuvid=911LK4dITcTjArUEJNCVKnp315z37y9BOk_yx8NWjB4-1751096848541-0.0.1.1-604800000; path=/; domain=.d3v-zenpydev.zendesk.com; HttpOnly; Secure; SameSite=None"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "cf-cache-status": [
+            "DYNAMIC"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "22"
+          ],
+          "x-request-id": [
+            "956b9383d9c13dd5-ORD"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.9.0"
+}

--- a/tests/test_api/betamax/TestEngagementsApi.test_fetch_engagements.json
+++ b/tests/test_api/betamax/TestEngagementsApi.test_fetch_engagements.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2025-06-28T07:47:28",
+      "recorded_at": "2025-06-29T08:13:15",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -29,14 +29,11 @@
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA4ySy26DMBBF9/0KxLqRDC4kZEee6qJppXRXVciCCbEKduoxfUX599pOUGmSVmFlzT0z157L9srzfFaC0BmI0hxqeyyYZr439J68rdEN0dF4YRU/mRFKZjQZpGQaj0YTSiZpSsZpOKApoWPiX+87Nc9foO0KDsW94b6WUBrHEY2iKA7IQS+VbDYdPUr6fRrS/uCgK3htADWoDtMn5gtI1M6Qq5XRNa8hQ8ilKNCSYXsDRF4K9yAtsxVXqDMFm+rzpIP8unMNiOaEWS4boU91O4Ofk7XUrMp+Lv7OuD7xig9wJYXx0Jfi+ZoJAZXL5W66XKbz28W8DaATHWqm7FCGUjg4dVuA4k/WOjoyJGHUI3GP3DySZBjEwzA80wSi+K9lcPRTGA/d4N7Ktdw/TBfnGTP5hDgy7r7LZuHllUQoPLOuN1DINDdqG5apmN5LF2zHN2ioM/EbYuc9W9AX8KGzjZ3bKJeGaKrKKWuGWS2VW8yKVQiu6lDkX64cXO2+AQAA//8DAJypaeONAwAA",
+          "base64_string": "H4sIAAAAAAAAA9TXS2/bRhAA4Ht+heCDT3E8s7NPAUbBxzIo0DpF3cehKARGWstCLNIlKad1kP/eJSVRfskOociWAB0IzSxXnOWn2f3yptc7SMcuqwYuG/uLaX05Sqv0oNfv/dX74uM+41ZsMqojBzpiyK1UwJm0QoVcJYaM5QEHLW0SHrydj6wmw09uOcqQ5HwRmE86/15JyZC0kaRJLeLjIp9d3Y6jNmAIzCJeuH9mrqxcscjREhhXDJhCokVOfn7u49Vk6galG+bZqKwzl9G0LCfjrHmoKh+cT4qyGhTu6vK/ByPgzm+eurL0V+VgmM+y6mG8vsfksXCVV+nlYPXDP6eT6sFcZlmAyzzzk1TfnD+8SLPMXTar87M9Owve/3j6frkMtxawrNKivmta5lmTHDR1cKO1ufWUTaavrjgCOiL8DaAP2BfqkUEuG60dQn3i914NP0c1K+dTNUM+/GJPH8/xd24yzj789IeN10x968l+zz5l+ees96ub5tdumZ9eu8IP+ObC1jedlT7tkYX3GV/frlcSG2U5KUYUJkxHiUxCGYDSWvBQk8W1SsQ2lfiwkVrik0rETitR1E1Jm//ySlgfTGcljD2n5NT+uQNI2rpugAQlKTKhJSmiiOIAFWeCAhYmmgIL61uJ3CoSBEDR/gk8jkTuNBIpuiFp818DCfLOSNDsB5K2rhsgCUhHWoTaMApFQiYAw4krI62/DCNYi0RtEYlknHE0+DQSttNIjOmGpM1/YSS86STQBQlv9lt7gqSt6yadhMck44AxoRkDYWLrgWg0wu+44gRoLRK9TSRUtyp65lDCdxqJ4t2QtPmvgQRZZyRM7smhpC3sBkqUiFhMQAKSmHNGcaSUEGBDDsgSEGuVmC0rEaTE061ktw8lsqMS+apKdHcle3Iokd8BCYsQowAxjgMbWa3imNsgCQOQiYdjonVIBGwPCQFDLpVS+9xKkLFuSlYDXpiJrplQJyZ+CO/z+5vxHWWyKuwGTiITIEirEqklklLINOrEv+0s8WDwfl9dOcEtNhMjhBQcOT7pBGGnoeiO3US/UjfRdWuATnuuhsnze67dYKK/QzcJBBNJxDC0NiZU/lxi49CCAKk1g9V/zAMlbMtKpP/stRKpuylp819DCWJnJWj2Q0lb1w2UcA2hFbE0MowC648pIUSRDP2l33eF7H5bXSmh7SkhRkJqhVI8qYR2GglCx16yGvCyTJDVey4hOjCph/A+7QmTVWGfc9L7u048yNy/1eCqvvOsmK/CRVVdlf3j4xvK0o9H5wy0MkcGzoGj4ABDkCMyfChS5hx8VIZh+u7Gz+bKT0f+kceTbPxumE+P06vJ8TU7Xj1o+cNqYQbDWVHmxQkqTpwxocThHa/L+HNkD5ufXk5u3AnC4eJlOrn7Ih1cpOVgmhfN0lbFzDVftgPnZXvz9X8AAAD//wMANJxRiKsgAAA=",
           "encoding": "utf-8",
           "string": ""
         },
         "headers": {
-          "CF-RAY": [
-            "956b9383d9c13dd5-SIN"
-          ],
           "Connection": [
             "keep-alive"
           ],
@@ -44,26 +41,13 @@
             "application/json"
           ],
           "Date": [
-            "Sat, 28 Jun 2025 07:47:28 GMT"
-          ],
-          "NEL": [
-            "{\"success_fraction\":0.01,\"report_to\":\"cf-nel\",\"max_age\":604800}"
-          ],
-          "Report-To": [
-            "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=GrcMwH%2BQy2fY9q%2F0wuwKgAxXUs89jONyuX%2Bw6umO5eG2dY1sgcC6AS7Vr90ccTx0nV02mtlsGo9ukp4f1sjmnl22xO79HFw5RvHdDBrTmShBnyUhWfHAy026mkfPDwDtSWfRtz7lenpdBQiGmaiGKMXpSj%2Fg1AasmQLWIlkuyVCVv6DTFV83SGkpBBq0TjKdvA%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+            "Sun, 29 Jun 2025 08:13:15 GMT"
           ],
           "Server": [
-            "cloudflare"
-          ],
-          "Set-Cookie": [
-            "__cf_bm=EdaiKylUROtqUBR5j4uWgBPVaeqP9CtwjOGezER_Iy8-1751096848-1.0.1.1-oa8T157EJVA15S76JbcVU9bYZeT02vH3aUY5EEA6OUWbmL8iFrliY8apnNC4a.ChOaisXagEIwThNNoQUAn6F7MBnY59bYW7PpQrVIje.So; path=/; expires=Sat, 28-Jun-25 08:17:28 GMT; domain=.d3v-zenpydev.zendesk.com; HttpOnly; Secure; SameSite=None",
-            "_cfuvid=911LK4dITcTjArUEJNCVKnp315z37y9BOk_yx8NWjB4-1751096848541-0.0.1.1-604800000; path=/; domain=.d3v-zenpydev.zendesk.com; HttpOnly; Secure; SameSite=None"
+            "openresty"
           ],
           "Transfer-Encoding": [
             "chunked"
-          ],
-          "cf-cache-status": [
-            "DYNAMIC"
           ],
           "content-encoding": [
             "gzip"
@@ -78,10 +62,10 @@
             "/api/v2/engagements"
           ],
           "x-envoy-upstream-service-time": [
-            "22"
+            "9"
           ],
           "x-request-id": [
-            "956b9383d9c13dd5-ORD"
+            "fe7e35cb954badf8995b7ea6371ee356"
           ],
           "x-zendesk-zorg": [
             "yes"
@@ -95,6 +79,10212 @@
           "message": "OK"
         },
         "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:16",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1743422575&engagement_id_cursor=480BE5D696BCAE75CB0CC6BAE7BA0B20&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXX2/bNhAA8Pd9CiPPDcDjkUfSbyJFFQPWtFi67aEPhhArqdFEai25RVHsu4/+q8yxHAuOYhkwDMF3R8qSfuLx12+DwUV6l+XVKMvvwsHD/HCcVunFYDj4NPgV4iHjUWwynkcuEqvIWS9RJjxRxijnuXZWekycVyAv3iwrq8nNl2xdZZCkWAWWky5/V0QcUBtCjWoVv5sWs6+P46ANM8jMKj7Nvs2yssqmqxxNDDlKMkZIXOUUt7chXk0eslGZ3RT5uJxn0voMynJyly/+VFWMbifTshpNs6/3P59UsP+d80NWluGoHN0Us7x6Gp+PMdkVrooqvR/VJ/4jnVRP5lLr07sv8jBJdXD+zec0z7P7xd1556+vo7e/X71d34ZHN7Cs0ul81LQs8kVytLgO2bgxdz7lIpMzLi8ZXiJ8BD5kOAS2oyjLx40lYshp69EIc1SzcjnVouTK/7M7JQy8SLh+/8ffPm6Y+dEf+yv/khc/8sGf2UPxPVvnp9+zaSg4+LrOB52VIW3HfQ8Z/75pRiJMhE6RZh6EB8WlBWIxF8ATjTFgIxLZJRJiwgAJuReJ7DUSaomETopEtkcCzyF5/8Ff9UAJvYASzSiB8NhybrTnBoG8JORhhUk4BA2NSqhDJRIFMpC0Xwn2WgkwaMekLnhlJzRkfAi8jROa05Lbr9C+Oqmv7BFQ0GmF3EXgNEcNmjSYWHNB6IVxMW+EojqEInT4aOD7ofS855LtnGzyT8GkbqAOZiKeXU560nPJ45GAizCmSLlEUxK52IbOC9FDrA2XpJs3JrpLJIKkkfUYu5GoXiOhlkjolEiw/VqC6jyQ0AsgYUFJ5BOrdcSAIiviONEmCY+pQR+J5pXEdIhECZDSGMS9SPrecmE7JXXB6zLhrHXLNS8JLdf2G7S/LRceDyVm1gtSSsiIrGGKgXWOeEwQ2ySB7VfGBgqxLqGAAGZAw14oPW+5qJ2TTf4pmHDVmol4dmfSj9Vkc12PQKIENzwyEMuwdECiuZUWVBJZRto6LxqRQJdIQrslJZ71vuRMWq4lEsTWSFCfB5KXaLmcDSuJAcetQufBWVImwThSkYBEKWpEwjtEYiQP3yT2I5G9RgLA2impC16Nibhk8JEtW64D15JNiRiyM9mZ1Bf2CCfexijAGYGcx2E/4jAmSZ5hpI21uN191k6wOyeChY9GMGqvE9VrJ7olE31KJYcuJpuSsDE5Rcf1HwAAAP//nFfJCoMwFLz3K4oHb5rdmIL0S4rENC6IC0ksRei/16WteGrp9e3DzBzeHy6JfzXJ8TIXeq2+u7SfBw9mJaF0rrcnAEbSyizIMYy5CATMIUVskqqC0ZUIqpjEWsOMC4xkOE7btK2DCXFRtUWougbIvgI3DDac9rzxkqrB2M4kiFNCI8YZ8Xdmfee/+dVfTrfVqBME/ZeWkr2OvFLatOnMwqwzg16Cn8b1mzs8ngAAAP//AwAMLmoMrSAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:16 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "15"
+          ],
+          "x-request-id": [
+            "e9531414ce4bcb32a1c73a98970cb1c0"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1743422575&engagement_id_cursor=480BE5D696BCAE75CB0CC6BAE7BA0B20&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:16",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1743465753&engagement_id_cursor=EBD341C94322D469C3D656E03A89BB35&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+TXW2/bNhQA4Pf+CsMPeWrqwztpIBgoiioGbOmw7PIwDIZq046RWMokOe1S9L+Pkq9prNiC68TGAD8I5jkkRfKDDr+8abXa8cglRc8lI/8wKR8HcRG3W93WX60vvt1HrLWNB2VLmwqmhRQccwmhQpohi5FA3IAywLRuv51lFuP+jVtkKcI5nTfMBp39LzjHiEjFiSRi3j7K0undejuSChQBNW/P3D9Tlxcum8dIDkQRSgVShMxj0uHQtxfjievlrp8mg7yaxWIGeT4eJdVLFWlvOM7yope5u9t/n2TAozlPXJ77p7zXT6dJ8bS97GO8qblIi/i2t5r4p3hcPBmLLxbgNk38IMXO8f3rOEncbbU7P9urK/3+x8v3i21Y28C8iLOy1zhPkypYV+vgBrWx5ZBVJAbMzoGeA/oNoAu4S9GGJJcMalNIl8pvjoYfo5jms6GqlA+/2MvNMb7nKuLqw09/2LBm6LU3+z25SdJPSetXN0nv3SI+vneZT9h5YctOp7kP27DxPuLr23olXNLIEBqYEIswksQEWFMAhUPmkTBTq4QdTgnFClGJ0TJmsxJy1EpWs9+RySrhhZ3Q0gmGJk58iv+pbU4u7Z9HwGS1sHs4iVAEXBuLuGSMGU0k59JqUFphiRmpdcIP6IRIiRT1M3rWCT9qJ6IhE/GaSohoqIR0GT8NJeI7INGUaBZZ0DRgzAILKdMWM2wlxRGPUC0ScVAkQuG1Pk4RyamUXBUSSpojgf9RyUUso5pYIwMU6dCAJlRTwRUNtQ4sr7+YyAMq8QWdQkqp55UcecmFoBmTVcILO5GlE5BNnMjKyalcTVYruwcUTCOwKqRKA0UQscA7AWFlaJEUAoe1UNSBoXAk8PM1lzhqKKdSc1VMMG/MhLITYfI9ii5pGQpQYE0oQhRyahTQMNJYRwQLg7/9si6VCDikEsoVEAnPK5FHrWR5ddu16OKvqITQ5kq2Fl3HcTNZrus+SKRiyEZcSPDnN5Q0iGTkjyfW0h/1gNQiQQdE4gsuCUDQSddcIJspWSW8LBOEq5oLNWBSpngm6jSYrBZ2Dye+vPInNwgEtiTExkT+W2KNkkYQY4DiWif4wE4YFVucHHnJJZoxWca/hhLU5GYyU0K2llzHoWS5rnsgCUykQs20QRYpFfEgslZRxSWToFlYX3GRQyIhRDG1reI6biQnUnHNkGDWHAk6DSQ7V1ytv8vAduI+F727suNpNtuE66K4y7udzgNJ4o/nQwxSqHMFQ6CIUYA+8AFRtM9i7Bx8FAqj+N2DH83lN+f+jUfjZPSun0468d24c487q/fMf1jtS68/zfI0u0CCEgZSUXb2COuifZvXs2rq+fjBXSA4m5+li8fnqH0d571JmlU7W2RTV/25TJx9gN98/Q8AAP//AwAUpEz1riAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:16 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "11"
+          ],
+          "x-request-id": [
+            "15c53e0935069e1c05e286acd97d9ea3"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1743465753&engagement_id_cursor=EBD341C94322D469C3D656E03A89BB35&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:17",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1743508945&engagement_id_cursor=BCF9DA5AC1E199F6BFEE94968580A5D0&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXW2/bNhQA4Pf+CsMPeWqaQx5eDQQDdWExYEuHpVsfhsFQbcYxGkuZJKdbiv73UbIj5yYnQuLazpPgcw4pkfrCo29ver1+MnFpOXTpxF/MqstxUib93qD3V++bj/uMW7HpuIr0JQWipLUQGWENcqmVkhxQsZhSpLL/dlFZTkdf3E2VRiHZMrCYdPG7FIISVFqgQrmMT/Jsfnk7TpQGjaCX8dz9M3dF6fJljhLAKWqpmASyzMnOzny8nM7csHCjLB0XVWZzB0UxnaT1Q5XZ8GyaF+Uwd5cX/z2ogDv3PHNF4a+K4Sibp+XDeDXG9LFwmZXJxXB141+TaflgLtLc/UWW+lnK5xeMzpM0dRf1/vwan56a9z+fvL/ZiFtbWJRJXg2bFFlaJ5t6Jdy4Nbeas86kQPkhsEMgH4kYAB2AfKTIpePWEhwwde/l8HOU82IxVV3y4bf45PEcP3Kdcfrhlz/jqGXqW0/2R/olzb6mvd/dLLtyN/nJlct9wfNXthp1Xvi8R/beZ3x/2w6FBIGUxJKAamSCa0GpAaBhxCRaa8JWKHyTUDgqAM3lWihip6E0C/RMJ03+NphQ0pkJiqeYnMSfdkBJs64vQIJUU2Q20FoxJJJSQZhRSAML1mpjWpGITSKRiguQgq9FIncaieiIRGwVSfezBOl+IBGvgMREXFmGIjBGhSxARiKGnNmYVc1X1I5EbhAJY0QDSra+5cKdRqJ1NyRN/o9FQqFCgl2QVCVsQJ48SXak4WoW9gVKbBjHRllkSoYKYoahJTYkJNSRCaiKW5WoTSpRmip/pq1XwndaicRuSpr8bSjh0FkJ4J4oaRb2BUoCGkvDIwTGGWgWSRPwUNDIYIAQKN2qRG9QCYrqTzK9x0r2pOFaKuHdlcCeKHmNjktLawnRJAwMqjBSDOIYteaKcsUEaVWiYINKhKJSatn8F9jHjosA6cZkVfAjndCPUDsB9mwnixIcML4nTlYr+wIoUoSCWxuFFqSIIVLEfxhEMpQUmZb0/lqsoJBNQhHgE1kzxj4eJ5J1bLrYFpkQ1ZkJ0j1h0izsS5TQCDS1gvPAsAh5TCMSMmM191QYtn6aKLpJJUz5TxNJ1isRO61EdFQitqmEdj9MqHpKyUn8aQeQiFdAIlRkAxnGJoJYKN97xXHV8PA4VKikvt9+rpDgBpEo4NXniV7fc+32UUKaJ3x2z6W3w4RVTLDTYcKqbxMq94PJamGfctL7u0rsp+7fcnhZjTzPF7twXpaXxeDo6BrT5PPhGQVP41DDGTDfeQGMQIxRsxFPqHPwWWpKknfXfjZXfDn0jzyZppN3o2x2lFxOj67o0epBi59WGzMczfMiy4+JZOi7Kc7VwR2vN/GnyB7Ut15Mr90xgYPly3R890XqnyfFcJbl9daW+dzVPzaFi2V78/1/AAAA//8DAF0CRCywIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:17 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "15"
+          ],
+          "x-request-id": [
+            "e5fbc12bf21c027c29e724c0c8993dcd"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1743508945&engagement_id_cursor=BCF9DA5AC1E199F6BFEE94968580A5D0&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:17",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1743566558&engagement_id_cursor=68DFB7CEAD0E6891CEE82775EC838790&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXW2/bNhQA4Pf+CsMPeWqawztpIBgkiiwGbEmx7PIwDIZqM46RWMokOe1S9L+Pkm05FyuJ5jmR3wzxHFIi+ZmH3971ev144pJi6JKJ/zErf47jIu73Br0/e998u4+40zYdly19EmCJOZFWkQBhyZkSzPCAaf9UYxn13y8yi+no0q2yFOGSLhsWgy6eC84xIlL5/ohYtk+ydH59tx1JBYqAWrZn7u+5ywuXLWMkByZ9PkMI0DImPT/37cV05oa5G6XJOC8j+eoN8nw6SaqPKtLh+TTLi2Hmrq/+eZQB99555vLc/8qHo3SeFI/byz6mm5qLtIivhusX/xJPi0djidUHXqWJH6R4cfzoIk4Sd1Wtzs/m7Cz4+OPJx9Uy3FnAvIizstc4T5MqOKjmwY0bY8shq0gMmB0CPQT8K9AB4AGjG5JcMm5MoQNEHmwNP0YxzxdDVSmnn8zJ5hjfcxVxdvrT7yZqGPrOl/2WXCbpl6T3i5ulN24VH9+4zCe8eGLLTue5D9uw8D7i+/tmJaB5xC1TKDAyNIaIkEmKVWixkDakslEJ26USTsH3g59WIjqthPN2Sur411dCBoBaKwGxJ0rqid1CiUY4sgHGUiCmdMilttYgxrCXoy3DjUr47pRwkBK4EHXMZiWk00pQbfyFTNYJr+xElqcJIW2cyNIJoc85OTF/dIDJemK3cGIFpsYqryJiRFKJOBbIBBoogohB82kidumESqXo+sTa7ER22kldlL6QSR3/FkoYa60Eqf1QUs/rFkgksdRiDJGIjBZhZPweNVprRBCjvuhpRCJ3iARhf5BgQciTSBB0WgkX7ZTU8a+vxNdc/0HJw0Kjo0rqed1CCcGcamIRl6GWjBoSIsmlpSSKtPYnTKMStUMlFFMOCp65mNBOI0H1F7605KoTXpcJwq1LrjKFDvCeMFlP7DanifJbGkt/D5EWE26EpuA3M9AAYYwD0+REwQ6dlOkMGH665OKddiJaMhFvqYRBayWwJyWX+B+QMBQof8kAFIS+1Ik0BP5cCbikwjBmHs3EGgnaMRJBBRJPIhGdRsJ5OyR1/JsgEe2RkP1AUs/rFkiC0O9boRDT3FrrvUTERNIaRKPIoLD5JME7RMIpZ1wx9TSSrldc0E7JOuGVmfDqYtKKCS+ZUPEck9NP5qQDTtYzuwUUjTknPNCCGSKsoSGyjBFsZWAEYVw3QiG7hMKR8udJff3Zy5KLtnNSx78FE4xaMyEPb60dPU3qeX0OSe+vMrCfuK/F8LrseJ4tFuGiKK7zwdHRLUniz4fnGKRQhwrOgSJGAUbAx0TREYuxc/BZKIziD7d+NJdfHvovnkyTyYdROjuKr6dHN/ho/Z35D+t1GY7mWZ5mx0hQwkFJQAf3sK7an/N6UL16Pr11xwgOlnvp+P4+6l/E+XCWZtXKFtncVQ/rxMV/y7vv/wIAAP//AwB7VnwYriAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:17 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "17"
+          ],
+          "x-request-id": [
+            "8699623abf6d751844832d63a8a64d6d"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1743566558&engagement_id_cursor=68DFB7CEAD0E6891CEE82775EC838790&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:18",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1743609801&engagement_id_cursor=C26636AC75E37FE4B1F5532F8AE7356C&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+zXS2/bRhAA4Ht+haCDT3E8+5rdIWAUfAYFWjuo0/ZQFAIj0bJgi3RJykkd5L93Sb38omTClk0DvRHcGe5ylx939vu7Xq8fj5O0HCTp2F5Mq8tRXMb9ntP7q/fdttuIG22TUdXSVz73AumaQEZMuYExXsRDl5NwtRf6Eeu/n2eWk+F5sswigSQXDfNO5/c1ImfCEAoj9KJ9nGezy5vtzBCQAFq058k/s6Qok3wRYxAQNQqujFGLmOz01LaXk2kyKJJhlo6KKhKXIyiKyTitX6rMBqeTvCgHeXJ58e+9DLg15mlSFPaqGAyzWVreb6+eMXmouczK+GKwHvjXeFLeH91y8BdZajspHx0/PIvTNLmoV+fX8OTE/fjz0cflMtxYwKKM8+qpcZGldbBbz0MyaoytuqwjOXC1D3If+GeGDgiH4wNJSTpqTJGOuPtp2D7KWTHvqk45Cv98OMQ+uA44Of7ljzBo6PnGi/2enqfZ17T3WzLNrpJlfHyV5Dbh0fNaPXRW2LAH1t1G/HjfjEQqrpXkDAI0ngLjGeEpAnQViEAptxGJ2h0SDUoyItR6IxLZaSQMWipZJ7wkE/EZwAHuKHo0k3mKdKTcxuT4U3jUASfrmX0CFHQNKc9ELPIMtz9y4fq+MehGFAjfMGiEgjuFYjQ3htNGKN3eTVbKH+lkFf/yTITDZGsm23eTjjBZTewTlEQMyAShqyT5GATGDSUZz0OjIyZ92Vxz6Z0qkVxpJjcr0Z1WgthOySr+NZRw1loJ12+k5sKnI9EeDxUyHSoRcfI1kR8wyZREIe12Qo1IzA6RCG67J4ObkXS95qJ2StYJL8xEVjUXE22YSKfOehtM1hP7BCdBxAKFQRhE5Nu6SxsfQQj7H8dIRMzFRie0SydKE3K9ZTPpeMnVkol+TSW81clEVvuPNG9DiX4GJCA9zjE0dk/xPOARcqGE4AQBSINR02aiAXaIRDIbiErpjUj+r7ieDYnQ7ZGIt4HkOSou34/8SAHX2pAETa7yOECIEbAAPLj7u1gjYTtEorhiWmrDNiLpeMUlVMuKa5XwwkxMxUTyNkxMVXGpN3IwWU/sE5zw0H7ZUXU2sX9v9Hzpu0YIz/U8xqRHd4vPtRO+QyfIyJZ9tMUJddoJtWRCr6dEOICtlUi2Tcnxp/CoA0zoGZSQ9gMtgHsmBO5yki6JAEMV+SIIFDXvJmKXSqQy3B5N1EYljHWaCbY8mOArHUxqJqxVzVUz4XfPrB3dTPCxB5Pe31VgP02+lYPL6sGzfL4IZ2V5WTgHB9cijb/sn3IwmvYJTkEyJQGGgCNBcqhiniTwRRNn8Ydr21tSnO/bNx5P0vGHYTY9iC8nB1f8YP2exU/rdRkMZ3mR5Ye2jBKIWpDeu6V12b4N7F499GJynRwy2Ft8S4e3v6P+WVwMpller2yZz5L65iqxxgXvfvwHAAD//wMAfk4Y+a4gAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:18 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "126d6ff640976d153d2cfd0713fd4ab2"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1743609801&engagement_id_cursor=C26636AC75E37FE4B1F5532F8AE7356C&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:19",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1743667397&engagement_id_cursor=97CD7302B8E02A294A93D6E5FC3DD598&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXX2/bNhAA8Pd9CiPPLUDyjkee36h/xYAtHZZ2e+iDYcRKZjSROktuMRT77qNkW3YTy4ngyZYBPwi5O1I6+Reev/80Gl1N79OsnKTZvb94rC5n03J6NRqPPo2++7jP2InNZ1XkioSO2AqdkBYCpFSsAAONSkIcJpG6erOqLOe3n9NNFYMRuA6sNl393RD5OssEFsw6fr/Il19249KyYBC8ji/Sv5dpUaaLdY4lYaxCaRBJrnPyuzsfL+eP6aRIb/NsVlSZsLmDopjfZ/VDlfnkbr4oyski/fLwz7MK8cM9P6ZF4a+KyW2+zMrn8WqN+b5wmZfTh8n2xr9N5+WzvXjzgA955jcpX51/+9c0y9KH+u38Gt/cuHc/X7/bvIadF1iU00W16rTIszrZ1X1IZ6251ZZ1phJKvxX4VsAHqcZCjTXtKUqzWWsJjkE/+Wr4PcplsdqqLnn/W3y9P8evXGfcvP/ljzhq2XrnyT5mn7P8Wzb6PX3Mv6ab/OnXdOELXt3YatFl4dP2vHif8e+bdiUStQtIIHMcOsNMJnBgI2t0JFxiw1Yluk8loI2UaPVBJXrQSgx2U9Lkn14JjAV3VqLgJSXX8Z8DQNL09QgkgoSQZDGOKEgCITCyBA5UBNq3xbUjoT6RGCDJgviCkZDuhqTJPwcSiZ2RSL6Qo6Rp7BFKPBLnIgwTJFQAoVZ+BJMkJTAkQiWtSkx/Siyi9vfA6vBRgoNWIpv/I69ksi04sROqRy7TxQlVTvDFw2QgTradPQKKi2JjjAqCWDpOQElHKkhCtgqSwE8+rVBsj1C0t2J31tgPxQwaijHdnDT5p2fijxPozATEhcxc5ngk4H2QVByTVjFHQT14EYcJh4CsXSsS7hMJaukT8fDMRYNGQh2R0FmRdPphUiNRdBlI6H9AomTiLEgbicR/WDOTDKRBnZgkDK1qQyJFj0hIC81KaTiIBAaNRArVdeRSZ2GiRMVEdTlLqhLtP5fBZNvYI5yIxIV+fIrBhGEIGq0NPBgAHUVMip8eq1snsk8nDIgvTlzDPkyM7sakyT+HErAdleBYv/jDZBhKmr4egUQ74JCISYSRjiRhmAR++JJCY6IC8bQTWySqZyTMEg4fJnrQSIi6IWnyz4EEux4lOEa+DCRNX49AkpjYxWCFjIRxUkaBM6H/joYRSg1+BmtFAj0iYQ1ABpU8iAQHjYS5G5Im/5RI8IOokYjXI1mVeCRPh/ETIfkPAAD//yI1k8DDlVAmUYgFKVTKS60oiS8AGVxaBImEjJKSgmIrff0q47zEJN00IwMLc0tdS4M0A2AWMTEwSDYwSzG2NEk2TTRKTTVIMrc0MkzUqwLallqcrQv0cXpmXrpecn6ufmJBpn6ZkT7Cn8X2iHiJTy4tKs4vsgV2dozNjUwsLYzVUDIrTJ5QflUDO704syrV1tBADZqWbFHTkVJGYnF8bn4ROGZLikpTwYJwjZBWKlctAAAA//8DAP3ohWSqIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:19 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "ba16b2dcfc2e960d529aa68e0d2ea0ca"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1743667397&engagement_id_cursor=97CD7302B8E02A294A93D6E5FC3DD598&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:19",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1743724983&engagement_id_cursor=F7EAE3801D07A11DBA7C693CD4153D0F&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SX227jNhCG7/cpDF/karMZcsghaSAodKAWBdpk0XS3F0VhaG3FMRJLqSRnt1nsu5eSTznJiZA4sQ1fCJp/eBjqwz/88a7T6cajJC37STpyD5PqcRiXcbfT6/zd+eHiTnEjNh5WkS4yMpJ8pi0nGfDIWoU++RFEFgBF2H0/yyzHg/NkkWVQMTEPzCadvVdEnKE2hBrVPD7Ks+nlzTjTBgyCmcfz5N9pUpRJPtdoAq2RKaUk4lyTnZ66eDmeJP0iGWTpsKiUcrGCohiP0npTZdY/HedF2c+Ty4v/7mXArTVPkqJwT0V/kE3T8n68GmP8ULjMyviiv1r4t3hc3ptLLQp0kaVukvLJ+sFZnKbJRX06v9uTE+/jr0cfF8dw4wCLMs6rUeMiS2uxV9chGTZqqylrJQcu90G4/58APcAeoweSknTYmCJ6CHc+DTdHOS1mU9Upx5/s0cMaN3KtODn+7YsNG6a+sbPP6XmafUs7fyST7CpZ6OOrJHcJTy5sNei0cLIHDt4pfr5vpkQb7mtGWpIACowIJCPhS6RQRcq3upESuWFKNEejdpgSku0oWerfghLOWlPC6TFKjuxfWwDJsq7PgESJAIEB9xwSQpNxLuKFkY60FX7kK68RErU5SAyiMYYBrocEtxoSo9tBstS/MiS6B7wHraxEV1wJsRuQLOv6DEgsMKuta7SIUBAaG0ntB2FklQr9iN2txAoSs0FIBBKAUI/0W7TVkOyKk9SQ8PaQINsNSF7CSTzPBJ4GG6gKC9RBYCPDPGNAGRawRifhsEFIFElwHZ9ZD8l2OwkDaEfJKuF1MWG8wkSKFphUKe5asiNesirsMzghGbn2xvoIkkuPDJAS2viIYSjdzzZywjbJiUTpREvNLl5LVEszUW9jJtUnjz1QrSnhfDcoUS9xLYm0UBQxxSKfBPiClPJ9T7AIladNY8fF+WbNxF1KjFl/LdluSHak45pBwrA1JEzvBiQv0XFFPAKlTWAlWiIImBAGZWjQXVWCMGzuuHBjkDiHRG4YMrHeScRWQ8KA2lGySnhlTKjuuHgbTKjuuB7F5PiTPdoCTlaVfQYojDHlrieaEyehpRWeDg1xHVkZcaOpERSxSVAkRyQu119NaKtBUbply6XfDJO2LVeNCZe74SbLuj4DEi+ygUIJJlDkMcG49TyriHHAUEi4W4kVJHJjkIAxhoxWJORaSNRWQ0ItzYTezktcyyXaQwK7AQk91Uk6/1TCbpp8L/uX1cDTfHYIZ2V5WfQODq4xjb/un3LQyuwbOAXBpAAYAA3RiIGMeZLAV2U4iz9cu9mS4nzf7Xg0TkcfBtnkIL4cH1zxg9U+i19W59IfTPMiyw+ZEqg0l0bs3YJ1EX+M17166cX4OjlksDf/lg5vf0fds7joT7K8Ptkynyb1y2XizIDf/fwfAAD//wMAyhZt96kgAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:19 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "08e0b69fb128ac8453772a864ef644d0"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1743724983&engagement_id_cursor=F7EAE3801D07A11DBA7C693CD4153D0F&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:20",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1743782594&engagement_id_cursor=AFEC73509C76A1412EAAE761203D4505&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXS2/bOBAA4Pv+CiPnFuDwMeT4xpeKBdqkaNLdwx4MI1ayRhOpa8ktiqL/fSU5trObyI7gyI+b4JkRaVIfhvz522BwNr5Ns3KUZrfVw339OBmX47PBcPDX4GcVrzIexaaTOnJmUUKMiEFFKZEoMgdWI8pY/Q6UnL1ZVJbT6y/psoqE5vgQWAy6+L2q4yAMoTBCP8RvZ/n86+M4GGIkGD3EZ+k/87Qo09lDjkGQSmrNGJllTn5zU8XL6X06KtLrPJsUzSyWMyiK6W3W/KkyH91MZ0U5mqVf7348qWD/mfN9WhTVUzG6zudZ+TRev2P6XLjMy/HdaD3x7+Np+WQsgOX87vKsGqV8ecH13+MsS++a/fkQLy/tu9/P3y034tEWFuV4Vr92XOTZYjOblUgnrbn1mE0mZ1y9ZfIt01ecDRkfCnymKM0mrSVyKNT/Po5qjHJeLIZqSs7jn8+nVC9uEi4v3v8RQ8vIj/7Y5+xLln/PBp/S+/xbuswff0tnVcHLF7Z+67yo8p7Z+irj15t2JxQF44kViqN2DL31OpLxzskYvOSi1Ynu04kAg1qB3ugE5FFDMaKbk1X+/pmIIVOdmXBzGkxW67qDEk4xEUZx5iFERswbizyyaB3GJPh2JabnbsIFR9ishB+1EuzYTfBwzUQMgXdXAtuUXHyM50fABF+hmbjEJkyBJW2rTuKEFZqUJ4doOdPRtTKhHploVAiGSbWRyXH3EmDQjcm6YJ9OzBVrDl3w8kPXokQMlT6NbrJe2B2cJCC9toqhc2RBYwyCGCjthQxkdWs7EaxPJxIBmSGx0Yk6aidadWOyyj+EEk6dlUh5GkpW67oDkuhcQkETssgZWJuoEBRy7bhRtjp6tSKBnpFo2HYzwaNGgh2R4CGRiJdfTFZI2GkgwVdAYhxXQpBzYIJiMZioZAguGHCEBO2dhPeIhAxVtxIwmy8mx91JDHZDssrfMxJZI2GdkMgaidh6L9mKJMT38ap3JauF3UEJjyoKgkDBeXTeK+kTaRVq5zww165E9qdEcc6ICPXmViKOWwl1VEKHUWIaJaKLEtMo4aeihHZXEmMEp4OAJEhIqstI9NImBqvPnFnuYqsS7FFJlUaSaTplJcB4Nybrgv06Ad446XIvqUvEUO3eTfZy5Fov7A5OvLbM+wTQgKy/UC9ctIll3EEQnrDVie7ZiQJYnSlP8WKiZTcmq/xDKOGysxJhtim5+BjPX5XJvwAAAP//nFTJDoIwEL37FYZDb9BpKWJNiF9iSKlliWFJF2NI/HdZFMKJxMscZp958+Y/miyL3WPJ8TY6eo162bQbEzs9o1Ba25kLxn3YiMzPKZxj7nPIgZGIAUg43UPOZCSoUpDFnBIR9EM1ZR7+MHFRNUUg2xqLrsJPitc5zXUFJpVOm1YnJGaMkHCQaMPWn32PsGhq3VS9Sgig7zEl20PySmHSutUTtFY7NSmXwPm5HN4fAAAA//8DAGciCHCwIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:20 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "a9be4fb3158f8a7ed4efcb39d062e3fa"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1743782594&engagement_id_cursor=AFEC73509C76A1412EAAE761203D4505&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:20",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744113744&engagement_id_cursor=C7A0CCF168146156C3BEAFA02B1D3C96&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXUW/bNhAA4Pf9CiPPLUDyjsej3yiJLAZs6bB020MfDCNWUqOJ1Flyi6HYfx/lOHLmWEkE17H8YEDw3ZEUxQ8kv/80Gp1Nr/OinuTFdXy4bR5n03p6NhqPPo6+x3jMeBCbz5rImQaHIkhFxqTsDSUhkSZhozKLmRXu7M1dZT2//JzfV1kwwOvAXad3/xsiJYEtAYNZx68X5fLLw7hkKywIu44v8r+XeVXni3UOk9RNljWbnPLqKsbr+W0+qfLLsphVTSbdj6Cq5tfF6qXqcnI1X1T1ZJF/ufnnUYX435hv86qKT9XkslwW9eN408Z8V7gu6+nNZDPwb9N5/Xh0ep19Uxaxk/rF+ZefpkWR36y+zq/+4sK9+/n83f1nePABq3q6aFqdVmWxSnarechnnblNl6tMJZR+K/Ct4A9SjYUag9hRlBezzhIYg95aGrGPelnddbUqef+bP9+dE1teZVy8/+VPn3V0/eDN/ig+F+W3YvR7flt+ze/zp1/zRSx48cQ2jS6rmLbjw8eMf990K8kkpj5jZREE+EQniZMuBIOGHDiZdiqxB1RiBSuF1LaxWwkOWokUoh+TTcErO6HGieI+TmIJjgU/5+Tc/zUAJpuJ3cOJQMnGBYxL14ksTRFRCdBoKf7rCbucoDigE5ZW6DgO/aQTPWgnBvsxafOPoQRlTyUw1s/uJsNQ0s7rHkg0ZZm2hkQadxNEqyV5GbwTIXgg2Y1EHhKJkYwCWD6JZOBHrp5I6KhITH8k8jSQ0A9A4thZiwG1jAszUcbpDC1AGgynxgbViUQdDgmJOBorAOCET1zW9kPS5r8uEiUaJAJ6IGlKYIzbS2Oo95J2YvdQAia1RJx4G+8jlCSZccYEtplw1ivdeS9BOKQSxWRByqfvJQM/b+l+Str8YyiRurcSEKexlbTzugeSTFo0OkUVlKfUaR9Ig0tThySNSrY31Q0SPCQSw4Lj75QvJdQTCR0TiRK9kagTuZTQD0CCWcoZM+ok8SKkEQhTEqwl643WBjqRmAMiYZSKQT9zKYFBI5Gyp5JNwWsysR8Er/YSfjGTuxIcy+3FMdQT12Zm94CSKEmZMJj6JN5LOAHIMg7GGw9WSb+9r26g8GGhgIonwaeh8KChtMpf6KTNPwYT6MsExtqeCJN2YvdQ4tlKn2ZBAcfjl+RUEoVAUnhqLGxvrBsl9sBKUBDZE1ZC3E9Jm38MJUj9leBRzlz/AQAA//8ivc1lQWQmUYgFKVTKS60oiS8AGVxaBImEjJKSgmIrff0q47zEJN00I2B3wFLX0iDNwMTQ1MTAINnALMXY0iTZNNEoNdUgyRxYuSTqVQFtSy3O1gX6OD0zL10vOT9XP7EgU7/MSB/hz2J7RLzEJ5cWFecX2RoCezOGFqbAnKKGkllh8oTyqxrY6cWZVam2hgZq0LRki5qOlDISi+Nz84vAMVtSVJoKFoRrBNfABly1AAAAAP//AwB4k4mWqyAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:20 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "12"
+          ],
+          "x-request-id": [
+            "e6c0adab0bdc6c96c73b44c61abe2c6e"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744113744&engagement_id_cursor=C7A0CCF168146156C3BEAFA02B1D3C96&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:21",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744185766&engagement_id_cursor=E891ECDF238D1918C166FF610E693745&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXUW/bNhAA4Pf9CiPPLUDyyDvSbxRJFQO6dFjS7WEPhhArmdFE6iy5xVDsv4+WHTtLIjuCI0d+E3J3pE35yx1//DQanWU3eVFP8uImPtwtH6dZnZ2NxqM/Rz9iPGY8iM2my8iZcwipI5OGhMtgg2YYkBx6AkJL6uzdqrKeXX3J76sMkGLrwGrT1d8JUXDQBkEDreM383Lx9WGca8MMMLOOz/O/F3lV5/N1jkZOzHACJQysc8rr6xivZ3f5pMqvymJaLTPvo1lVzW6K5kvV5eR6Nq/qyTz/evvPk4r/f+a7vKriUzW5KhdF/TS+XGP2XLgu6+x2sv3g37NZ/WQvzvg6/bYs4i71ywuu/sqKIr9t3s8v4eLCfvj5/MP9i3jwCqs6my+XzaqyaJJtcxL5tDV3uWeTKZhQ75l8z8wlF2MmxmCeKcqLaWuJHAv26McR96gX1WqrpuQ8/PF8Sly4Sbj49PH34Ft2fvDFPhdfivJ7Mfotvyu/5ff52bd8HgtefrDLVRdVzHvm1ceMf9+1O0l1QswTIXERpUhlhTIJCcaDTyyXrU54n04USYFG8p1O1KCdkOrGZJP/FkqU6KyE0Wko2ZzrAUikS0kkBsCjNZ5Szr1HB1I5lXDr2puJ6BOJ1kxqvaeZDBsJdkSCb4pEd0cCp4EEXwGJJoaKcwOoXBpIIXhhvXCYmCRNpWlFAj0iAQKhyOjdnUQOGglnopuSbcGRmeCSCevEJJbAWJ3MxCUOd4LMoQBrldUuXgXiYcR/5Nz6YEikhlyrE9mjE8ljomZ7mgkO2smpTFyNEgGdlYDep+TTr+F8AExeY+RSXCB5ZUOK2mmUHhJKfSBDnqWS2u8lqk8lTBmtEHd3k2ErOZWRa6XEdFfy+KcxVCWvMXMpTJjXOlXWxwsKWOa9TjGIoDRoQe0zF/aoRAkAMCjVTiXDnrlAdlOyyT+uEsGai0kXJcuSqGTvxWS/Eh8+hsvemWxO9gAmKWdBWxU0ipCo1IpExptKkM4GkwR83Fe3TKhHJgiMYkvZrHGKzUR0vJls8o/PBMa8y8i1ZqIOvpgcR8nmYA9RQtGI48wZ7UAJrbwXUrHgnGMSmWhVontUook0gFa7LybDbiacsW5MtgVHdMLZJWvaCcOXOlmXwFjiwU6OMnNtD/YAJ4K7JIBLYgsRkCRGok+cT6QI5FG6x51168T06MRICYo4391N1KCdUMehi95g6Noo4S8eujZK9g9dr67kPwAAAP//nFfJCsIwEL37FdJDbm2maWqNUPwSKWlMF0oXsogE/He7qKUnxevsw5s3zPzFkuTXk2t/mQy9Tt5NNkyBrVpAqIwZ9AljF3U89wsCx4T5DAqgYUwBBByuEaMi5kRKyBNGQh64MZvUjT92XNZdGYi+xXyo8Y3gtU99XnHJhFW6V+l4RFFCp58Dbcj61n/jK5pL17WTaQjoNUvpdo68iuus7dWMrFFWzsKP47Jbdo8nAAAA//8DAPqegB+vIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:21 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "59f0bf4d1e5e20df55d35d10e3cde903"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744185766&engagement_id_cursor=E891ECDF238D1918C166FF610E693745&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:21",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744243339&engagement_id_cursor=21CBE3CB51123BB946DBCDB42E7D64C3&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9yXW0/jVhDH3/dTRHngaVnmzLlbQpWPfbyq1LJV6eWhqiJvYkIEsantsC2r/e49dhIHGgxYEIj7ZmX+c2bO5ZeZ+fpuMBjG0yQtR0k6dR/z6nMSl/Fw4A3+GHx1dqe4ZZtNKsswtFqpCIyvZaB4hNqG4BtJOdcSNMLw/dKznI0vkrWXplLAyrAMuvxdCoGEKi2oonJln+bZ4uq2nSgNmoJe2fPkr0VSlEm+0ihBpJIKgCvFV5rs7MzZy9k8GRXJOEsnRaUU6wyKYjZN602V2ehslhflKE+uLv/Z8rib8zwpCvdVjMbZIi237dUas/vMZVbGl6NN4l/iWbmd3Tr5yyx1Qcon68fncZoml/Xt/GhPT/2P3598XF/DrQssyjivVo2LLK3Ffn0OyaRVW4WslQjID4EdEvgFwAP0kN3jlKSTVhfqof7P03AxykWxDFW7nNjf75e4hWvB6acffrNhS+RbG/s1vUizL+ng52SeXSdrfXyd5M7hyedaLboonOyee3eKb+/bIdHWojBogUS+5EYHIggNFdRCSIlA0woJ2R0kiqCmSmIT435I6F5DolU3SBr9K0PCPCAe110gYRUkVPYDkuZcnwEJotAqFJIQHgij0XALllnLAq2NMO2VBHcJCTChKYeHIeF7DYmk3SBp9K8PCXoEO0OCvB+QNOf6DEh4pEPrgyFhwK2wKmAmhNAA0coIvvV3sYGE7hISV0m0IqzPkPSl3VpCIrtDgo9B8ukne7IHlLxEvxUxsAF1LxOB+4wGGMgo8LkmPGQBVaSVErZDSkSNCGvW6GO/RZpC+ERMNg6vzImqOKGdOHEuzCOqJ5xsTvY5g4nGiEUyiCImGUrOfYMqDEOIFGr0g1ZQ+C5BoS4XLpV+EJT9LieyYzmRb1ROakw46YwJiJ70XC9QTZShIeeMIvJIoESDNmR+CMpGwprNVLcFidglJG7uAZCPDCZ6ryFpJren9lz4ZpBQD6A7JI/2XPsBSXOuz4DE58wiFWC0ZFpEIrChBitcWWGWB0BbIZE7hEQzIhgSeLiSsL2GpDctF8G6logOmFQuzNuaWv/XLZcxlEVcETcMUBJJjYJbAMLARJpJP2wFRe0SFNRCESEeriZir0HpSctVvXnqkS7VZIkJ8n5Uk5douVC5YSQ0YC0JUQpAEwqJjhrqR4ZG7dVE7xISqZRWLoceQ9L0pE9tucRbQsK7Q0L6AUlzro9BMvizEg7T5O9ydFUtvMiXl3BelleFd3R0Q9P48+EZgpL6UMMZMMIZwBjEhGo25jEmCXx2dYbEH25ctKS4OHQ7ns7S6YdxNj+Kr2ZH13i02Wfx3eZeRuNFXmT5MXFtHCrBNT+4A+va/hivB3XqxewmOSZwsHpLx3ff0fA8LkbzLK9vtswXSf1j47gswO++/QsAAP//AwBtJD5gqiAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:21 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "562c167ebbd85ee3cf6548915fd14636"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744243339&engagement_id_cursor=21CBE3CB51123BB946DBCDB42E7D64C3&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:22",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744286595&engagement_id_cursor=28275DB0EE1D27602BD6725813AFB3F3&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+yXTU/bQBCG7/0VEWeQdma/c1vbu6hSC1Wh7aGHyEoMjQCbxg6oQv3vXTufhTiJFQKmqpKDlXlnx57dx/Pm4V2ncxBfJmnRS9JLf3FTXg7iIj7odDvfOw8+7hVLseGgjByI0NhQRTYExRlYROZUgAJR+Q8j4cHhJLMY9q+SWZamUpJpYFJ08rsUAoEqLaiichq/HGXj2+U4KE00JXoaHyU/x0leJKOpRgnQFKlWXghTTXZx4ePF8Cbp5Uk/Swd5qWSzO8jz4WVaPVSR9S6Go7zojZLb619PMv6+55skz/1V3utn47R4Gi/XGK4KF1kRX/cWN34fD4sntYDM5NdZ6qsU2yf0f8RpmlxX+/PRnp2Z4/cnx7ONWNrCvIhH5bJxnqWV2FSdSAa12rJmpUSC/IiwIyDnILqEdolckZSkg9oU1mXy0eHwNYpxPilVpZzYb6slfuFKcHb64auNaiovPdiX9CrN7tPO5+Qmu0tm+vguGfmE7RtbrjrOvW7F1nvF78N6TmwUgkZiBDpjueNSCyUpdyABgQWulhPYIyfItOQCFV/LCW81J5I1w2Sufw1KkDSmhLJNlJx+sictwGTe2F0oCcFJDejf3w5lgKFVWkeSM6VloMDUUoL7pAS5AP+laykRraZE8GaUzPWvQoloTgm8jVky7+sOkIAw6M9uoB2nRtNIG2f9QbaSYgRc1UNC9wgJZwQlZWT9KGm75YJmlCwSXhYTJF2CXdIEkzKFbmG5WjJMFp3dARRd/hNx2jANIfUmS1HFUDtqPTeBdaQWFLZnUDSKDaC03HM1nCbydabJBBPQjTF5O57rGcaJ06GSwJFLCLhRmtmAEws6YC5goQpqKeH7pYQSxA2U/Pdcz0YJ8uaUPH6B/sOei2rFlXCRo2CDgEsdWjQoLDchZYD1o0TsERIliVB8oVkNCbYaEiCiGSWLhJfEBM5JdeYJbI3JJIVt4bnagcmisTtwwpBbzTFixlghLYTWCe64tejAGVS1nMg9cqLBE6qZWM9Ju4fJvEHbWi75ipSAbEzJZsvVDkrmfd3FcTlKolAACaIo4KHSlCsllSEGqQQR1kKi9gkJAYqMM3jDkLTPcf0BAAD//9SXUWuDMBDH3/cpRh98s8ldTmMGUlrXjzHEurSVUZVExxD23RftNunDWoR1rK9JLsnlfz9y/zOQIE2GBNVtQPIbHZczABIxfFwmADJaK2dJloEIknWykpGgn22JuhokyN1HghAKkGchoX8NCQCfRskY8MeY0GBMcAom1GMCeBuYjA97iZP7p37hrNRvTVr3O7fmqMK+aWr7wFgnymzjb5FHUvmKbzlBQJznPHwWivIgQ635RiqEbN6507R98V3Ku6LczfPqwLK6YK/IxkTtYhQmzVtjKxODJBJEQOid8Po1fwlZb7i6LTodA/c+iyk+LaTZPrPpoTKDtI1p9TD4HXhsVO/ePwAAAP//AwBMAdzFsCAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:22 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "aef84a8aec89d8b7584aba46f0b8cefa"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744286595&engagement_id_cursor=28275DB0EE1D27602BD6725813AFB3F3&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744344142&engagement_id_cursor=4037226DAC1178E90E1A535CECB7834B&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SXS2/jNhDH7/spDB9yWq85HD4NBIVEUYsC7RZo+jgUhaG1acdILKWSnG2z2O9eSnbsvJSNkDixboLnPxxyhj9z5uu7Xq+fzF1ajl069x/L6nOalEm/N+r91fvq7V5xw7aYVpY+KA2MSkWNVaGKkVAQCkIZRqisjaP++7VnuZicuWsvjVKRjWEddP27FIICKi1QodzY53m2urhp9xGJRqI39tz9s3JF6fKNRglKAChlIARsNNls5u3lYunGhZtk6bSoV7veQVEs5ml9qDIbzxZ5UY5zd3H+3z2P23teuqLwX8V4kq3S8r69WmPxkLnMyuR8vNv4l2RR3ou1TdB5lvog5ZP1k9MkTd15XZ2f7clJ8PHHTx+vy3CjgEWZ5NWqSZGltTio8+CmjdoqZK2khPIBYQOA3wgbETpC/YCTS6eNLjji+s7V8DHKVbEOVbt8sn8+LPEL14KTX376w0YNkW8c7Pf0LM2+pL1f3TK7dNf65NLl3uHJea0WXRVe9kDdveLb+2ZIGNdorOQkCEACD0wINPZ33F9T1MaIRkhg35BwyWWHIRGiHSRb/VtAwmR7SLAbkGzz+gxIYk0l01RxE6E0oWTIteUQaxVBGErbCAndIyR+CaU5o4+/JHjQkACBdpTsHF4ZE1VhQkkbTLyLJwW6gckusc/ghALVGEIUqZiGEBiiDAdGFAgTeRxoIye4X040UMb4o5zwg+ZE8naYbPVvQQliS0pwxFQ3KNnm9RmQiIBIC1KjFTLQsdU8CEIjlI0JCivjRkjYPiHRQlOUEjsMSVc6rjUkqj0krBuQvETHxRVVjGlhrLFE6ABYbFDZkAVgImnu/l3sIOF7hERqIrgXP95xsYOGBAi2o2Tn8LqYAK0wAdoCk8rFDya8G5jsEvucyUQSbayKYsFDP6WEQWBjCLWMubE8IqaRE7FPTpR/T7j4TsclDpqTjnRca0qobE0Ju9uMHyglL9FxMcoNjUMMY0OtRIwAo1gTFXISRTRu7rjkPiHxj4nCbkPSkY5rDQm2f0qwI2PJS3RcJIKQWkKYDZgIJdVaKU7DGAPNjSKyERK1P0iACCY9KqLLkAC0fEp2Dq+Miag7rjaDSeXCRoDdwGSX2Od0XAQiZThQZYSVcaRiJa0kBjmAJaaZE71PTihKTjWXj3IiD5oT1XIwUW80l9SUoGhJiZ9LdDcoUU8dS3p/V8J+6v4txxfVwqt8XYTTsrwoRsPhFabJ58GMEiX1QJMZYcAZIRMipqjZhCfUOfJZagrJhysfzRVnA3/i+SKdf5hky2FysRhe0uHunMUPu7qMJ6u8yPJjkIyhksjF0S1Yr+3f4/Wo3nqxuHLHQI42d+n49j3qnybFeJnldWXLfOXqH7eO62nu3bf/AQAA//8DAAHetBmqIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:23 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "e438f69c8ace558fec51d5479353050a"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744344142&engagement_id_cursor=4037226DAC1178E90E1A535CECB7834B&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744387356&engagement_id_cursor=F01D8C5128C6E7FD8F87E70C3511E0C7&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SX32/bNhDH3/tXGH7IU9Mcf5MGgkESyWLAlg5Ltz0Mg6HajGM0ljJJTrsU/d9HyY6UX3IiGK7lN0H3PR515Ed39+3NYDCMZy4pxi6Z+YdF+TiNi3g4GA3+Hnzzdq+4Z5tPS8uQI4qslDrEklEbYkNoQGWACQQWQq2Hb1eexXzy2d15KSIUrA2roKv3gnOMiFScSCLW9lmWLq/v25FUoAiotT1z/y5dXrhsrZFeApgIxhVma016ceHtxXzhxrmbpMk0L5Wo3kKez2dJ9VVFOr6YZ3kxztz11X9PXB5ueuHy3D/l40m6TIqn9nKN+XPmIi3iq3Gz8y/xvHgSi/O1+ipNfJDi1frJZZwk7qo6nl/N+Xnw/uez93fncO8E8yLOylXjPE0qcVDlwU1btWXISokBs2Ogxwh9RHwEeET5M04umba6kBHDj+6Gj1Es81WoyuXDb+bseY1fuVKcf/jlT6NbQt/7sj+Sz0n6JRn87hbpjbvTxzcu8w6vTmy56DL3smcO3iu+v23HJLRKq8ByEmItLcIRlZoZIiwEkgpEWzFBO8QEcwmcCIo2YkJ7TQkC1A2TxuHHcoJhhMQIZAdOShc5ouolTs7MXz3ApEnsFpxYLFTIZCi1RUYjFBhlMKWMUoKlwWErJ3i3nPiSIuRmTlivORG0Gya1fh+UYNyZEsIPpJrUid2CEswUMEt1KHmEGBDki0lEGEOEEm1w1EoJ2SUlFAAriQ+ZEs66UVLr90KJ6E7Jiz1XP2pJndctIDEq8hMJ8EBof4OlIFr5e87AUG4iE6BWSOgOISFKYU4F3zyZ8F5DglDXlgvto+XCHwHK0aRprl/EZOVCR8AOpJg0md0CFGER8yOIAB4RhUgAYEwoZKgVpZGgjwtrAwrbJSgMc4EwVhtBkb0GRUI3Tmr9PjAhqCMmZMQe/0N7Wk3qvG4zmNjAhtpoP5wwEgShjRTigiDGVCgZhVZI+A4hoRgIJ0KQjZCoXkPCZTdIav1eIJGdIXny/+wpJHVet4BEWyStJVwoxRXFOBQYWaQisJHFGkwrJGKHkDBJgUkpxEZIaK8hQahjKWkcfjAmtMQEky6Y0LLlQuQwMGkSuwUnoQCDWaSF5cZoGUAEjFtpWSBY+VNv5UTukBMODAH4VnAjJ6LXnAjVDZNavw9KmqbhlZT4jksdBiV1XreAhGOirTS+u4HQX06NAu4R4BozEfjb+nhEayBRO4SECUIR5Wxzx9VvSDjvBkmt3wskojskB1JK6ry+BMngn1I4TNzXYnxdLrzMVodwWRTX+ejk5JYk8afjCwxSqGMFF0CRH0lgAnxKFJ2wGDsHn4TCKH5366O5/POx/+LZPJm9m6SLk/h6fnKDT5rvzH9qzmU8WWZ5mp0iQSklvlCJowew3tlf4vWo2no+v3WnCI7Wd+n04T0aXsb5eJFm1ckW2dJVL2vHqgDDm+//AwAA//8DAFO/jKSuIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:23 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "11"
+          ],
+          "x-request-id": [
+            "19ea7b38622ba20989d1387897474b61"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744387356&engagement_id_cursor=F01D8C5128C6E7FD8F87E70C3511E0C7&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744430567&engagement_id_cursor=623DF8E7730B160D1A69376D257A2165&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TX3W/bNhAA8Pf+FYYf8tQ0dySPHwaCQZTEYsCWDk23PQyDodqKYySWMklOtxT930fJsZ0vOxESJ/ab4rsjKVK/kPz+rtPpJqM0q/ppNvIPk/pxmFRJt9Pr/NX57uM+40ZsPKwjXRMY4CBDp5XjClkchKFWVseChGKx7b6fVVbjwVk6rzJcA1wHZp3OfldSMuTaSK65uo6Pinx6cTOO2oDhYK7jRfrPNC2rtLjO0T7Fh5G0wnkb+cmJj1fjSdov00GeDcs6k89HUJbjUda8VJX3T8ZFWfWL9OL8v3sVt8c8ScvSP5X9QT7Nqvvxuo3xQ+Eqr5Lz/nLg35Jxda8vhPn4zvPM91I9vWBwmmRZet6sz6/x8XHw8eejj/OFuLGEZZUUdbNJmWdNctDMRDpcmVv32WQyYLQPYh/ZF9A9YD3gDxSl2XBlCe8Jeefj8H1U03LWVVNyFP/5cIpvuEk4/vTLH3G0oucbL/Z7dpbl37LO53SSX6bz/OQyLXzB0ye2bnVa+rwHlt5n/Hi/2omOEE3spAHE2DowgY2lYc7FWnOSbKUT3KATTYwJYzSudUJb7UTJdkwW+W+hBFVrJZw/puTTb/HRFjBZTOwzlAiUHDlCYBlFLFIeTRhoB9yq0NC9fxhLJWyTSpRhRilt1ipRW61EUjsli/y3UMJEayXM7MZespjXZyCxUUhIJgYe80hZCIlZa51xoLgkWI2Ebw5J3YZSAILWIhFbjQRRtFOyLHhdJshaM6lLRA/1bjBZTuwznEiHjqJQhP4LBs2UoAhj4zwVJRzS6quJ2LATDVKu30z0VjvR0I7JIv8tlIj2SkDshpLFvD4DibEkbMBjFqENyQUssooCF1h/CAsiQyuR0AaRgEJCILZ+M9luJLLlvUS+zb1khoRYSyS8RzuylcgXuJYwHToZEQpBFEHoFLdxaA2EMghDFdy9oS2RyA0i4YJxzoH4WiRbfuJaXNyeeuJaFLwyE1kzAd2GiWyYwG4wWU7sM5xA5BSTQhpC49B/osyftwSPBQ9C5Qxb6URt0gkj4igfuZnQVjtRLTcT9UabSaOEYWslXO2GEvUCm4kUBixSwIhHluKII0bccUvEQmbV3W11iURvEgkpRQwkrkUitxrJrpy4ZkhUeyR3zxlbiuQlTlxU7x6BNMbEVmrHWOD/VnGI2rnYbyUrkZgNIhFKMlIC1u8kfKuRIPB2SpYFr8uEQc0E2zCpS0QPdubExZ/opPN3ndjN0n+r/kXd8rSYrcJpVV2UvYODK54lX/dPGGhl9g2cgEASAAOQQ27EgBKWpvBVGYbJhyvfW1qe7ftXHo2z0YdBPjlILsYHl+xg+aLlT8uF6Q+mRZkXh6iEEFojV3u3vM7jj5Hda4Zejq/SQ4S964/p8PaH1D1Nyv4kL5qlrYpp2vy4KJxN27sf/wMAAP//AwAyGqJLriAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:24 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "46e958856ae89dfffa800d544f3333ef"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744430567&engagement_id_cursor=623DF8E7730B160D1A69376D257A2165&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744488137&engagement_id_cursor=51223A6999EB68F22A2237EC18FFE7F9&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXW2/bNhQA4Pf+CsMPeWrqQx5eDQSDLmQxYEuHpt0ehsFQbcYxEkuZJKdbiv73UfItcWI3gufYfhN8ziElkp9JfnvTarWToUvLnkuH/mFcPQ6SMmm3uq0/W9983Gc8iI0GVaRtTcwI6ogY1BZBM66UFv6JhpFW3LbfTivLUf/azas0KgKzwLTT6e9SCErQ16NCOYsP82xy+zBOlAbte5rFc/f3xBWly2c5SlDKJJGEcT5vI7u89PFyNHa9wvWzdFBUmWL+BkUxGqb1R5VZ73KUF2Uvd7c3/z6pePzOY1cU/qno9bNJWj6NV22MnguXWZnc9JYv/jUZlU/6knyWfZOlvpPyxfn9qyRN3U09O7+ai4vg/c/n7+fT8GACizLJq1aTIkvr5KAeBzdYm1t1WWdSoPwU2Cmhnyh0gXaRPlPk0sHaEuwyubI0fB/lpJh2VZecmz+eT/EN1wkXH3753cRren7wYZ/T6zT7mrY+unF25+b5yZ3LfcGLx7VqdFL4tGfm3Wd8f7seCXKm4zCMiZaBlowIDpZrqqwNVRjaYC0SsmMkFJAcMxLREInYKxLVHAkeBxLxPyARRGsZIolCZiMpCNeBtYowAQHoiPO1SOgOkUjknGquNyPBg0ZCgDVTsix4TSb4CaZMyIuZTEtYl6wujidMPvxmzg/AyXJkt4DCYwNUGiqk9SctFZnQCB2EgaZRjJqu7qtLKLhDKEIwqSgiboTCDxqKlM2cLPL3wYTxxkyAHgmTxcBuoSQOA2siQpkBSUIV+O2EKmQkFEYARKsb61IJ26ESySlqALJZiTxoJUI0U7LI34cS/vKLybQEu1wdyZlLbI8kiLmJGBf+gKUwlFTHLPCrXAYmjiiI1ZFYIuE7RKKZIto7JBuRHPaZS+tmSBb5r4yk2hS6BJogYfXFRB8HksW4boHEehU20iZmzFQDgcYfvCwKC3EcGWXWIhG7RIISUXB51OctbIZkkb8PJBQbI0FxLOct3F5J5K8lsdQWIMTYCs04VxyjUFuibITrlchdKhGMAgLwI1YieDMli/y9KFHNlawexQ9VyWJgt1BilA01J/5sFVAZMqWAkUDF/n4CEeciWKtE7U4JEopeq9Zyo5LDPnARoM2YLAte2YmqFj00upf4EtZl7EicLEd2CyihBIiIFbFiVoJRnEaCW6GEiSmPNFkLRe8SimBI0De1EYo8aCiy4XYi97Sd1EyIbMwE6Y+YHMbNRL50N2n9VSW2U/dP2butGp7k00m4Ksvbotvp3GOafDm9pKCkPtVw6bcUzgD6IAaoWZ8n1Dn4IjUlybt735srrk/9Fw9H6fBdPxt3kttR5452lt9Z/LScl15/khdZfkYkY9wvfi1PHmGdx3/k9aR+9WJ0784InMzW0tnjddS+SoreOMvrmS3ziat/XBRO/1vefP8PAAD//wMA9TT376wgAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:24 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "18"
+          ],
+          "x-request-id": [
+            "a285037cf4c03cd2c4dbb544af6440b2"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744488137&engagement_id_cursor=51223A6999EB68F22A2237EC18FFE7F9&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744531397&engagement_id_cursor=B700C1F6D84F70E852C65F686ED25C91&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXS2/jNhAA4Ht/hZHzLjAcDoekb6JELgq0yaLp49CDYcRKamwibS15F8Wi/72UX0qTyI3gOpbhi+CZIaWRPpD89t1odDG9y4t6khd38eKhuZxN6+nFaDz6ffQtxmPGo9h81kQuHGgBiRIhpMCpZuc8Q8bgrFQi1ebi3bqynt98yrdVVhqETWA96fp/zYxCGsvSSL2J3y3K5efHcWEsWAl2E1/kfy7zqs4XmxzDKAVpJRFwm1Pe3sZ4PX/IJ1V+UxazajXa9g6qan5XrB6qLie380VVTxb55/u/nlX8+54f8qqKV9XkplwW9fN4M8b8pXBd1tP7SXvjX6fz+tlcrDbZ92URJ6lfnX/zx7Qo8vvV2/nRX18nH76//LB9DY9eYFVPF82o06osVsnJqg/5rDO3mXKVGVur3gO9F/JnMGOQY5QvFOXFrLOExvj004hz1MtqPdWq5NL/9nJKHHiVcH31w68+65j50YP9Unwqyq/F6Kf8ofySb/OnX/JFLHh1X5tBl1VMe+G9x4y/33UjSQMnPpECLXNw7BQqlQayRkmjMck6kYgjIpFsjTCa9iOhQSMRgvopaQvelonAhglQDyZNCY3VfzK5+ugvB+Ck7ewBUAS6DINWLn7byrEO7FK2waQpI0HQnVDwmFAMWtRk1F4ow15NDPZzsss/BRPE3kyIzmM12fX1ACRAYI2zRGh8KlzmjUgNU+oYgBCedqJFIo+JJO66pLZC70ViB42EdT8ku/xTIJGiNxJ5LlsufTgS78AGj8LrEEKWoVBCskmdjqcTwdp1IqEjIlGKGEjb/UjkoJEI0XMpaQvemAmPAcfYiwk3TIQ8DyZtYw9wkrmGQwIJoQg6y3QWgtIanLPeOPe0Fa0TdUwnlhGlJrHXybB3XNr2Y7LLP4USgp5K5FjZ81Cy6+shi4miNE3YqjT+rLTaZJhkZDBB64N92okWCR8RCYPFeEoy54zkXHZcayS6P5IzOZb8LzsuhAACEh9PAsoGxcLbVKALluIiI7ETiT4iEi2tlIas3IuEBo1EgOqnpC14WyYIDROwPZg0Ja9hcvXRXw7ASdvZA6AIZMdpErwmmTCBkhlbZzLppPLgu7dc5shQlASj9kLhQUPR3M/JLv8UTFD1ZkLiPFaTXV8PQEIgM6JEkpbIGAI7ScgKIHCABEwnEntMJHECTUD7kQx8y9VzMeFTriXtruHVSKQ+BZJ/AAAA//+cVskKwjAQvfsV0kNvbSZpYoxQ/BIpaUwXSheSVKTgv9tFLT0pXmcf3hve/PFy/aok+8sU6DX67pJuKtybBYTCuc6eEBqiRqZBRuDIRSAgA4oZBVBwuEaCKiaJ1pByQbAMh7GbtlUwbpyXTR6qtkayK9GNoHVPe15xSVRvbGtizCllnDJG/M2xvv3f7tWfR7floGMM/otL8ZZHXiFtUrdmRtaZXs/GT+IiwLvHEwAA//8DAA4vDv6sIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:25 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "11"
+          ],
+          "x-request-id": [
+            "591d2257007ac29d6bc6e23d726aac39"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744531397&engagement_id_cursor=B700C1F6D84F70E852C65F686ED25C91&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744574552&engagement_id_cursor=403D44A3473262FF6B3426500F6F0A08&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXzW7jNhAA4Hufwsh5F+AMySHpG0VSiwJtsmj6c+jBEGIlNTaRtpa8i2LRdy+lOLbrRMkKjmI5JyEzI8qUP3Pm2w+TyVl2kxf1LC9u4sVdcznP6uxsMp38OfkW4zFjJ7aYN5Ez8kEwm4AUwIxJKEGW2NSR09KlytHZu/vKenH1KX+oMlxztg7cL3r/f0WEwLWhGFfr+M2yXH3ejYM2zHBm1vFl/vcqr+p8uc7RhNxIIUmh4euc8vo6xuvFXT6r8quymFdNpnh4gqpa3BTth6rL2fViWdWzZf759p9HFf9/5ru8quJVNbsqV0X9ON7cY/FUuC7r7Ha2ffCv2aJ+tBYArNNvyyKuUn9/wdVfWVHkt+37+TlcXtoPP55/eHgRO6+wqrNlc9usKos22bY7kc87c5s120xkKN8z8R7Er4xNGU65fqIoL+adJWKKZu/LEdeoV9X9Um3Jefjj6ZR44zbh8uKn34PvWHnng/1WfCrKr8Xkl/yu/JI/5Gdf8mUs+P6Nbe66qmLeE68+Zvz7rtuJTnXClUqkSckLJRGkQbQiCJemyu9vxdYJDOgk3kELYko960SN2oky/Zhs8o+hRKreSmD/J3SkSjb7egASJOulZGgjEk7OWExRKQqARvNgQicSHPgw0Ts5p4iEVD8km/y3R8Ljl74/EngJycXHcD4CJZuNPUBJSJzmWgeLMgRvjAwUuVjlIY2nScI6lfDhlAiMeVISPN9y8VErMT2VmCMpEc1RwqCPEtHA2vZo4z5KzCsgwVRrIp+6xMsESNsQzxIRMDAXZwPffZSIIZFgnJGEfgGJHDUSxfsh2eQfAwnw3kjwVPotfjgSZ0QAqQiIrCQnU8tlEhyzQXMKLu1EIgdFAowxjc/3W+NGQrIfkk3+UZDo/kj4aSDZ7OsBSHhQcRyxnmKXpR1JcAgBydhEpp6c7URCAyKJf2CatBNut4Dpfkq2BW/MRDdMsNdYotuxBE+DyXZjDxlLAnHBBIFR3ifGGAaGFEPtvSWW7v9ibJ2oIZ2QEiAkymed6FE7UT3HEnWksaRVInp1XK0Stj+xjlSJeoWxJEAA5LG98sggjcdKUIAicWS88C7d34ktEj0kEqaQA70wlqhRIzmVjqtFIllPJHwq5WkgeY2Oy7oUUwGploxrgSpxJvZdBjFYRBG6Oy4zHBLJENEQIzjhjsuYfkg2+W+LBHDKYCpVDyRNCZ9yegnJxcdwPoSS/wAAAP//IjGXwAOWUC5RiAUpVMpLrSiJLwAZXFoEiYWMkpKCYit9/SrjvMQk3TQjAwtzS11LgzQDE0NTEwODZAOzFGNLk2TTRKPUVIMkc0sjw0S9KqBtqcXZukAfp2fmpesl5+fqJxZk6pcZ6SP8WWyPiJj45NKi4vwiW0NzYEPKGJhNzNVQcitMnlCGVQM7vTizKtXW0EANmphsUROSUkZicXxufhE4akuKSlPBgnCNkGYqVy0AAAD//wMA95I9xakgAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:25 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "ae5caf6c044cac71ae4ebd06446a87b7"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744574552&engagement_id_cursor=403D44A3473262FF6B3426500F6F0A08&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744632117&engagement_id_cursor=ACF2F41F85038427BC9C65922EA224EA&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXS2/bOBAA4Pv+CiPnFhi+hhzf+FKxwG5abPo49GAYsZI1mkhdS25RFPvfl7JjO40jbwTHsXwTMjMiTfELhz9/GwzOxtd5UY/y4jo93DaPk3E9PhsMB58HP1M8ZdyLTSdN5CxY5SHImEWZCRPJqPSsBbOgpAvBnL1aVtbTyy/5qoqEkXAXWA66/LtG5EwYQmGEvotfz8r51/txZghIAN3FZ/k/87yq89ldjkEuiRthDJlVTnl1leL19DYfVfllWUyqJlOuZlBV0+ti8aPqcnQ1nVX1aJZ/vfmxVfHrnG/zqkpP1eiynBf1drx5x/SxcF3W45vRZuLfx9N6ayy9mt5NWaRB6ifnX/49Lor8ZvF1/owXF/bN7+dvVp/h3ges6vGseeu4KotFsl2sQz5pzW2GXGRy4Oo1yNdMvmd8CHzI4JGivJi0loghlw+2RhqjnlfLoRYl5/HT4ynpxYuEi7d/fIyhZeR7P+xD8aUovxeDv/Lb8lu+yh9/y2ep4Mnr2rx0XqW0R757yvj3VTuSCAaRxbR7Q/CgjSVnpUUZvY2ggm9Fwg6MhAiZ2IkEe40EOyLBoyLB7kjgNJDgMyDx0lHIyMm0syFtXa+45Rm4gEY5FR6uxAYJPxwSxQQyVFrpnUj6fZKwNfEnKtkUvDATbJiA6cIklcghsNNgslnYPZygzSwTNtM27XDFbDpaohFKZIGQu6hanYhDOkFlGE9ZO53oXjvR1I3JOv8YSrjuqEQMJZ6GkvW67oGEKaOZj5bIcw2WSVDCG9LWMZchZK1I5AGRABlOpNjuw6TfSNB07LjMEZEI0R3JiRwl63XdAwmQVRhFQwVlyBCtjFw7YB4UiM1/mC0k6oBIJKACZOucU+y4qCMSOg4SDot+i3VA0pSIoaDTQELPgASZRyUiFyRVxqQQqcfiJkBS4jMJ7UjwkEh4A1T8z0nSbyS6461EH+dSskTCupwkSyT8VNqt57iTqGCNTXtaORm98Zh5cI5MarciiShakegDIkmzYai1ZDuRYK+RoOyGZJ1/FCTUHcnDrdFTJOt13QNJkJjpDGK6gUSlSDqRtid4lDJjDh20IjEHRNI4ISSzu91SvUbCuO6mZFPwkkzUe1gwUfBkJssSOVQP24wtJm/fxfMeONms7B5QfNCCs+hDFkg4BzLjAShwAd5pL9pbLjokFEDDDXG1EwpjvZZCrBuUdf7LOxFDZjo7kce6mPwHAAD//5RXyQqDMBC99yuKB2+aSRqNFqRfUiSmcUFcSGIpQv+9MV3EU9vr7I83j2H+fUzwjyrZn5dAr5c3k49L4Uk9SaiNGfURofnQ8yIoCSQsDVIogeKIAgiIL/ZjEREnUkLBUoJ5ONtuUreBRVw1fRWKoUN8bNCVoBWnPq285GJSelAZZpTGzB6KxN+o9e3/Jljfja6bWWYY/NcuZds98mqu825QjlmjJumMn0QnLtjdHwAAAP//AwCWFzX7qSAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:26 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "11"
+          ],
+          "x-request-id": [
+            "02bc570b36c1e6d907979a5fd77ae397"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744632117&engagement_id_cursor=ACF2F41F85038427BC9C65922EA224EA&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:27",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744675398&engagement_id_cursor=CD7321ECDFD93BB04F2D09D230CB7C37&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+yX227bRhCG7/MUgi58Fcczuzt7EGAUPCyDAq1T1El7URQCI9GyYIt0ScpJHeTdu9SJPkk2Icumi1wIoDj/7GGWH+bfb286nW48StKyn6Qj9zCpHodxGXc7vc5fnW8u7hTXYuNhFekqFrEwNICWWa6JGfTQY8wzoFRE1nTfzjPL8eAsWWYZp4RFYD7p/L2SkiHXRnLN1SI+yrPpxfU4agOGg1nE8+SfaVKUSb7QaMlICgmogOFCk52cuHg5niT9Ihlk6bColMiXSyiK8Sid7arM+ifjvCj7eXJx/u+dlJuLniRF4Z6K/iCbpuXdeDXG+L5wmZXxeb9e+Zd4XN6ZSy53eJ6lbpLy0frBaZymyfnseH61x8fe+5+P3i/P4doJFmWcV6PGRZbOxN6sDslwrbaacqZkwGgfxD7SR4Ae8B7He5KSdLg2RfQE3Po23BzltJhPNUv58Js9ul/jRp4pjj/88ocN10x9bWef0rM0+5J2fk8m2WWy1MeXSe4SHl3YatBp4WT3HLxTfH+7HhPNQ0TPGhNKI1C5P8KCFYIkGUb2dilqTHCHmGhANIaT2ogJtZoSXFH8SEzqhGfmRPSA9ZhqwomoOGEPcnJk/2wBJnVht+AksJ4S1jKjIwU25CFHxa1VBJ6vI89fywnbJSecodBabm4nutWcaGiGyUr/EpQI2ZgSkK+km6wKuwUlwMIgUJ40vrNfnrCRtMQNBcKzUSAjtpYSvlNKjKl+m7tJuymRuhklK/1LUEK8OSX4OnrJqq5bQMKN0IJCBlp4moTwvEChVQqk70e+DtdCInYHiXQHorgyenMraffFxHnXppZLvAwmusIEqAkmurrN0O1ra0sxqQu7BSeeRcmCyBCz7k5CgY9GSoXa95UwsMFy0S45EcSVdt7vFTeTFeSPtVz4gpSw5pSIBy1XOyhZ1XULSNCXvgoiRAUGiSJlfTIaolA7w+WH0VpI5I4hMUrRD8f1TJDwRo5rDsmDjqsl95KnsFyRdLcPJAmh8MOAfG4jIQIbGSAg5um1lKgdUiJREicSZiMlotWUIDbsJXXC83KCsvroUTTgpEqhay6t3c2kLuw2lkt7vlGCQUi+lIKRCBV5HENQhgK47T5rTvSOOdGMyc2cqFZz8kos15wSjg0pET1ir4OSp7BcQkd+QBIJDcpIAXKPKddMMGA2snS7r9aQmB1CQpobqYSmjZD8sFxPB4lpDIlQ/zfL1fm7EnbT5GvZv6gGnubzUzgty4uid3BwxdP48/4JA63MvoETEEgCYAByyI0YUMySBD4rwzB+d+VmS4qzfbfj0TgdvRtkk4P4YnxwyQ7qfRY/1QfTH0zzIssPUQmhOAc0ezdoXcYfAnZvtvRifJUcIuwtPqbDmx9S9zQu+pMsnx1tmU+T2ctV4qwDw5vv/wEAAP//AwDJZubbryAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:27 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "ee2c818f1298c10ba92ad5452dd1d18b"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744675398&engagement_id_cursor=CD7321ECDFD93BB04F2D09D230CB7C37&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:27",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744733019&engagement_id_cursor=48FBC56151916F7013A27CEF1C2EFE51&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SXS2/bRhDH7/kUgg4+xfHsc3YEGAUfy6BA6xR12h6KQmAkWhZskS5JOa2DfPcu9aJflEWosqUbofnPzu7M/jSz3951Ot14lKRlP0lH7mNSfQ7jMu52ep0/O9+c3Snu2cbDytINhUXiCj1Cq3kYWBX5UaBIkQFOxLrv557leHCVLL1IGA0Lwzzo/HfUmjNhSAsjcGEf5dn05r6dGQISQAt7nvw9TYoyyRcao7k2HABI6qUmu7hw9nI8SfpFMsjSYVEp5XIHRTEepbNDlVn/YpwXZT9Pbq7/feLxcM+TpCjcV9EfZNO0fGqv1hg/Zy6zMr7u1xv/Go/LJ7EYYwv5dZa6KOXmDoPLOE2T61l9frbn597HH88+Lgtxr4RFGefVsnGRpTOxN8tEMmzUVjFnSg5cHYM8Zuozhx7InpLPOCXpsNFF96R6dDlcjHJazEPNXM7sH89L3MIzwfmnn363YUPkewf7Lb1Ks69p59dkkt0mS318m+TOYfPEVqtOC6d7pvRO8f19MycQeEoqgihkAlGFWvkQaFKBJ4gZTzZywnbJiSQuOFdiLSd6rzlBaofJSv/6lKgeY60pEfASJZ9+sWd7gMkqsVtQwlwTMb61WmDg8VAqK5CiEDgjj8g0dxO+S0qUZo4Tw9ZSgntNicZ2lKz0b0KJaU0JP5BessrrFpAI4bvxidy1FFL5wkToMe0rsNJaGWIzJGJ3kCAQY6gFw7WQ7PnIBbIdJbXDa2KiP4O787ynaGNM5i6yJ8VhYFIndgtOZMQChjziiqxV4ElSlntWaxEE0t3oRk7kDjlhjlpEMOqQRy7dDpOV/vUpET22+cNkScnhjFx6e0qM5G7gotB1Dm2YD0qTFTJAw33JrX38h1FTonZICXChNDjhAVOyStCmI5d6Q0o4tKbkYEYutT0kWgrLQo9hFPEoDLlrJ74nkPmuj7h7+jgTNSR6h5BwAkQUcv27ZN9Hrpa9pHZ4ZUxkNXLVld4EE1lhAo/n8X1tJnVmtwBFcTdxGRn4HqjAKOMZL2IMPJIUcc1lIyi4S1C0EwLx9TMX7jUoiO04WenfAhPBWmIietIcCCarxG5BCQPSJDQqq4TPRGSCUGjPRD6SRZTUSInZISVu4pIgxEFTolt2E/2WzURge0oej+P7Son+X3oJMuMTC9FDRUGkPYXukeJD4AcU+H4jJbRDShRK4FKhWEuJ2GtKGPC2Qxd/G07MbIJq9TZxLqon+YFwUmf2JVA6f1XCbpr8U/ZvqpWn+bwMl2V5U/ROTu5EGn85vuBgkI4JLkAyJQEGoIeC5EDFPEngCxJn8Yc7Fy0pro7dkUfjdPRhkE1O4pvxyS0/qQ9a/FBXpj+Y5kWWnzKUEglcpzh6AOzS/hKzR7OtF+O75JTB0eI2nT68Sd3LuOhPsnxW2zKfJrMfV47ztL37/h8AAAD//wMA1KchDbMgAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:27 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "9fc86147e60445035e7cb46f079d7633"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744733019&engagement_id_cursor=48FBC56151916F7013A27CEF1C2EFE51&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:28",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744790640&engagement_id_cursor=52718B91D7A759CF6A57D76B0CBC9CBB&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXS2/bOBAA4Pv+CiPnFuBrhkPdxFexwDYpmn0cejCMWMkaTaSuJbcoiv73pfxMGyuJ4Li2AR8EzwwpUfpAzrffBoOz0U1RNsOivEkXd+3leNSMzgbZ4MPgW4qnjHuxybiNnGkluZDG2siM4CKPinnrubeC6dywePZqUdlMrj4WqyojSbNlYDHp4n+NKLgkg5KkXsZvptXs0/04J8OMZGYZnxb/zYq6KabLHEKhwUghpdCrMarr6xRvJnfFsC6uqnJct5m4uoO6ntyU84dqquH1ZFo3w2nx6fbrg4of7/muqOt0VQ+vqlnZPIy3Y0y2hZuqGd0ONzf+ZTRpHsylYZl9W5VpkubZ+Vf/jsqyuJ2/nbfh8jJ/8/v5m9VruPcC62Y0bUcd1VU5T87n61CMO3PbKeeZggl4zdRrjn8yypjKuNpSVJTjzhLIhPnp00hzNLN6MdW85Dz8sz0lDTxPuLz44+/gO2a+92B/lR/L6ks5eF/cVZ+LVf7oczFNBc9e13bQWZ3Strz3lPH9VTcSiTokJY7nPqIhJZhyYIUljy4yKTuR8H0iUZq4TkOdMBLsiQQPiUSw/kjgKSQX78L5ESjBF1CCCoQLHIzLMbeRlIoKIqCgBAWU6FQi9qgEmSGCTc52JeqolXDO+jHZFPxyJ1xlQP2ccMwUncZmslnYHZwI9BYxj44bHo1yXGtG3uYMhLfBh04nco9OIO1qxAyc8pGLejKhwymB9OutRD65mxyHEnoBJCiCsoYcKGvbL9wb78FpVIZxR6x7M1H7RAIpB546cumjRoK6H5J1/iGQCNEbyan0Jet13QGJYxHy4K2VlikbY/rGHXqpI2grtHSdSGCPSFI1JYYEjyI59hMX9T1x0UGYcJExkUnswaQtUZlUp8Fks7A7OGFGkFBpBzFGR5eaEskhRB+0I8ydt51OcJ9OQHGFTD3uxBy1E8P7MVnnH0IJ6N5KxJN9ycW7cH4ETNYLu4MSnkOeW2I8dQEWOHMutSkmIpAFwICdSvQ+lRA3EoQwJ6wEe24meLi9RGasT1+yUMLliSjBF9hLcpFrDRp9FEqCA+QUEAGltSyI8HOLtlFC+1NCDAUzWtPjSuRRK+EM+jHZFPxiJzg/c/VpTdqS5ESfiJPNyu4AJVpmeUytCEXpJUuHLQyWnI8kVbBKdEIx+4SihBKGE38UCh41lPWp9JlO1vmHYKKoNxN2gNbkfwAAAP//IieXwMOVUCZRiAUpVMpLrSiJLwAZXFoEiYSMkpKCYit9/SrjvMQk3TQjA2Di17U0SDMwMTQ1MTBINjBLMbY0STZNNEpNNUgytzQyTNSrAtqWWpytC/RxemZeul5yfq5+YkGmfpmRPsKfxfaIeIlPLi0qzi+yNTQ3MQE1psws1FAyK0yeUH5VAzu9OLMq1dbQQA2almxR05FSRmJxfG5+EThmS4pKU8GCcI2QsoWrFgAAAP//AwBXksD0riAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:28 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "4f3f3d79d3298647c6cc4f1f8b1daf49"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744790640&engagement_id_cursor=52718B91D7A759CF6A57D76B0CBC9CBB&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:28",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744819368&engagement_id_cursor=FB0B1FF578F3D30E7C6EB8CDF834EB42&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXS2/jNhAA4Ht/hZHzLkAOySHHN4mPRYFtsmjS9tCDYcRKamwibS1lF8Wi/72UH5Lr2K4FV7EN+CB4Zkh5pM8kv/8wGFyNH7O8GmX5Y7x4ri8n42p8NRgOfh98j/GYsRabTurIFXlFMvFcMtDemWC49IpJyYihNqCu3i0qq+n952xVRcIYtgwsJl18rxGBC0MojNDL+OOsePmyHueGGAlGy/gs+/MlK6tstswxCIbVaSAMX+YUDw8xXk2fs1GZ3Rf5pKwzcXUHZTl9zOc/qipGD9NZWY1m2Zenv15V/Puen7OyjFfl6L54yavX8XqM6bZwVVTjp1F749/G0+r13all9lORx0mqg/Pv/xjnefY0fzo/+dvb5MOP1x9Wj2HtAZbVeFaPOi6LfJ6czPuQTXbm1lPOM4GBes/ke453HIcMhkpuKcryyc4SMVS08WrEOaqXcjHVvOTmk7/enhNHnmfc3nz81bsdU6/9sl/yz3nxLR/8nD0XX7NV/vhrNosFBze2HvSljGlbHnzM+PvdbiVWomM+2giWmBRWSu4El47I6mhnsxWtEt6jEjAaDVNNznYl8qyVcC66MWkL3tYJsPql59DBSV2i4udCnLSdPQJKSiKQTSRpa43jnpS2zkiTEFM6JLuXE+gTCgAJgbAfijlrKM16e6CTJv8UTATvyEQOFf8vJtf+tzNQ0vT1CCSAVgWReIKghdUBjIfEsTT4gExZuxOJ6BuJgWaMS0SCuhuSJv8kSKgzEokXspY0jT1CiQmCaWRpStprnjKBQViFFJGAku2O9ZUS2aMSKVFJRKP2KjnvkwnnHdeStuAtneg7NnfCDl9MFiWXs5i0jT3CCUltQhIkVw45MUZGB+28TzV45LDZitaJ6tGJYgKEQSX2OtFn7URTNyZN/imU8MNXk5USYS5DSdPXYxYTo3Ti44uLTCruPNcuBJkmASIfJfROJNgjEhl3XCSV2r/lOm8kiN2QNPmnQALYHQlcBpKmr0cgSa2xztsgpBbeQ2q8JwteRDlIPN19LtE9ItGogAll+F4k8qyRxEZ0U9IWvDETOWSwtn06hEkswSFsbse7M3H+o7/r3Unb2WOggHPKxL9u5l2qhU2dS4XTlKYhng+Szb+MForpE4oAJhHY/qOJOWsonFQ3KG3B20OJR5NOm67LgtJ29ggoKNByTQRBJsLH15hSR5R4mWJI0ISdUKhPKPF4ItAAXTIU03Hf1RacAgo3PUC5+eSv/y8p/wAAAP//pFfJCsIwEL37FdJDb20mMbWJUPwSKWlMF6QLSSpS8N9N41J6UvA6+8ybBzN/MYX9enttT7Nh0KmbzYc58qifONTWDuaA0LTrRBGVBFjKIw4lUJxQAAn7s/sUZCKIUlCknGARTy6bMpfI9Vw1XRXLvkViaNCVoKVRc1ygyeWoTa8znFLqeJBwFq4Y+9Z/I23oSzfNpDIM4WudsvUqBbUwedtrD67Vo/LCj6MfG2zuDwAAAP//AwCe+VyXtyAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:28 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "ae47f2492f71e644f3c08d8bc9ac80f7"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744819368&engagement_id_cursor=FB0B1FF578F3D30E7C6EB8CDF834EB42&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744862598&engagement_id_cursor=636C17992F4A3E2119BD99AE4B6FA68F&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SXTW/jNhCG7/0VRs67wMyQnCF9oyRqUaDNFk0/DnswjFhJjU2kraXsolj0v5ey4491YjeC17F8EzTvkNSQj97h1x8Gg4vxbVE2o6K8jQ/37eNk3IwvBsPBh8HXGI+Kjdh00kYuILOOMmDiTJsgRATkVVA5u9SSURdvFpnN9Ppjscxyyjp4DCwmXbwXZsIYY2WVPMZvZ9XDp804xlynwD3GZ8XfD0XdFLNHjWVyiICbmurmJsab6X0xqovrqpzUrZKWK6jr6W05/6imGt1MZ3UzmhWf7v55kvHtmu+Luo5P9ei6eiibp/F2jOlz4aZqxnej9cK/jKfNk7kQluu7q8o4S/PyhOu/xmVZ3M335+dwdeXf/Xj5brkRG1tYN+NZO+y4rsq52M8rUUx2ats558q4y+Yt6Lcov4EdAg3RPZNUlJOdKXoIuHU44hzNQ72Yap7y/pdw+bwmjjxXXL3/6Y+Q7Zh648t+Lz+W1Zdy8GtxX30ulvrx52IWE15e2XbUhzrqntn7qPj3zW5QEHKNSUbKIiqXZpZTRy4kKXjRLk93goJHBkUry/tB4V6DIqYbJyv9KTBRuiMmaqjdmWCyKuwBlBD5BLQ31mPwpCUk8UeeCzJQliOZnZTQkSkxTltzxpRwR0r4lJRo6E7J9tHoKyX8HSgBz95TJimpoIMFzDEzzKyMywzwtq+uKVFHpEQzkSDRfi+xvaYEkbthsk54XU6QWk4IO3DSpughyplwsq7sAaD4gDmQTlMrQRILlDOBJEblSWIAsp2g6GOCAoqdaNhvJ/0GxepunKz0p8Ckk50sMAH9f5hchj97QMmqrofcTFJ2icpznRqNILm07VS8kiht0hBku/1cQ2KOCYlI6ycW90KCqteUcEc34VOaielqJmpozsVM+Dt4iU3iLSSEVAhsyOLxDM6mkkqmtJPM776a8BExsYjaIfD+pkv3mhKkjmayTnhlTnjedFEXTrh1E+LzcJN1YQ/gRMWDnWjlcg4+pBCbL62INIfMe6/89i9jzYkckRNxprUUUXs5Qeg1KNZ042SlPwUmmjtjgtsX177ayaqwB2CSm4yDEkEKntigIXB57sVrnUGe0k5M7DExkdh5KWXknDFZmeFLuy53QkxMd0xgu9XoqZus6noIJSnqRHKTW860FsUgYqQ95qwDwLavrilxR6NEAQpYQ0T77ybca0gQqWPTtUp4XUwIWkxQdcCkTXllTP4DAAD//6Kk0QUPWEL5RCEWpFApL7WiJL4AZHJpESQWMkpKCoqt9PWrjPMSk3TTgB0Uc0tdS4M0AxNDUxMDg2QDsxRjS5Nk00Sj1FSDJHNLI8NEvSqgbanF2bpAL6dn5qXrJefn6icWZOqXGekjPFpsj4iY+OTSouL8IltDcxMTSyMDQ2NjNZT8CpMnlGXVwE4vzqxKtTU0UIMmJlvUhKSUkVgcn5tfBI7akqLSVLAgXCOkEuKqBQAAAP//AwANKnY4tiAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:29 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "a80067890909b5d7c0cdfb85ae44a359"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744862598&engagement_id_cursor=636C17992F4A3E2119BD99AE4B6FA68F&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:30",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744920133&engagement_id_cursor=FC14B7F5F86D4473607757638364E006&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXS2/jNhAA4Pv+CsOHnDZrkjN8GQgKPahFgTZbNNv2UBSG1mYcI7GUSnK2zWL/eynZkfOSHcF1rNwMzwwpkfow5Ld3vV4/ntqkGNlk6n7My5+TuIj7vWHvz943F3cZ92KzSRnpU6EUk8wIESoOQoWMeIp5QDUPBCDrv19WFrPxpb2r0qAJWQWWky7/l0IwCkoLUCBX8WmWLq7vx6nSRAPRq3hm/17YvLDZKkcJIJQKwoEhX+Wk5+cuXszmdpTbcZpM8mq0uyfI89k0qV6qSEfnsywvRpm9vvr3ScXDZ57bPHe/8tE4XSTF03g5xuy5cJEW8dVo/eBf41nxZC5FV9lXaeImKV6cP76Ik8ReVbvzszk78z7+ePrxbhvubWBexFk5apynSZXsVetgJ4255ZRVJiOMHxM8pvIzI0PChkCfKbLJpLEEhvzxp+HmKBb5cqqq5NT88XyKG7hKOPv00+8mbJj53ov9llwm6dek96udpzf2Lj++sZkrePG6loMucpf2zL67jO/vm5HoUHmeIjTURngh80H4BrVvDPGROjSNSOg+kWgHRKLQG5HoTiMRsh2SOv8gSHRrJCjeBpJ6XXdAIiLXN6gWfuQr0IyqiAtJReShx4AL3YiE7REJEs0Y0WozEuw0EkqgnZJ1wWsyUZ9JxYSoFzNZlrheQrcx+fSLOe2Ak/XK7tJNEJmJiMBAGx4S5vkMSYABI+70pThvhAL7hIJacIUaNkIRnYYiRTsndf4hmDDWmgk8Pmh0tJvU67oDElNeSjgVIQ18z91H3OGLqUApHzTnvv+4r66R4D6RuEYicFs36TYSwdshqfMPgqR9LwF4I72kXtgdlAQIyCD0BJUiRI96CKFSihLl+9p5aVTC96hEcs6EUoJuVAKdVkLrN3zxmUsfxgmWTii0ceJKyqo34mS9sjtA8dz5igvBuZG+YZEM0XCpmJRRFALnjxvrGorYIxRFKCLFGuPzUGSnociWTuQhmQBpyQSG+Pje2tUz1/+AJPJ0xKQxgEp7jIooIiQyPmcRw8A3XiMSuUckZTfRkrDN3aTbSIRsh6TOPwgS2R4JvpFeUi/sDkooR6Gp8aVWHgpDISJcBj4q6gXAg+ZWovanhFKJBBUnm28m2GkllIp2TNYFr+xElU6w1ZlLlWcu2NpMOuJkvbK7XE5CIUGxkGnKJXdHLjAQ8YgKA46LHzZC0XuGohiyzVC63U4UtHNS578+ExgS2poJ29pOunHmqtd1G5LeX2ViP7H/FKPrcuBFttyEi6K4zoeDwS0k8Zfjc0aU1MeanBN0XYaQMRET0DjmMbOWfJGa0fjDrZvN5pfH7o2ns2T6YZzOB/H1bHDDBuv3zH9Y78tovMjyNDtxnz46P6Do0QOsd/FtXo+qR89nt/aEkqPVt3Ty8DvqX8T5aJ5m1c4W2cJWf9aFy/vcu+//AQAA//8DAP0O+fmvIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:30 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "13"
+          ],
+          "x-request-id": [
+            "f91e88b946726cdf050b884b152a66ad"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744920133&engagement_id_cursor=FC14B7F5F86D4473607757638364E006&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:30",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744963381&engagement_id_cursor=CD67382D2915757D43E3F5F16E3CB4BD&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXQW/bNhQA4Pt+hZFzC5B8j+SjbiRFFgPatFi67dCDIcRKZjSRWktuURT776Mc28mayI3gKrF9EvzeIylSH0h+/20yOSkuy6qdltVlerjuHmdFW5xMssmHyfcUTxl3YvNZFznh6CUit8wyRRFDUE5bHiFE7Rk4efLiprKdn38sN1UGDGfrwE2nN/9rpQQHMgoI9Dp+uaiXn+7GORlmgJl1fFF+XpZNWy7WOaSAc5SMlGBynVNfXKR4O78up015XlezZtXaZgRNM7+sVi/V1tOL+aJpp4vy09W3exX/H/N12TTpqZme18uqvR/v2pg/FG7rtria3g78azFv749uk31VV6mT9tH55/8UVVVerVbnTTg7s69+P321WYY7C9i0xaJrtWjqapVsV/NQznpzuy5XmYIJ+ZLhS07vGWUMMkYPFJXVrLcEM04/fBqpj3bZ3HS1Knn7Lpw+nJNaXmWcvX39V8h7ur7zZn9WH6v6azX5o7yuv5Sb/OJLuUgFj57YrtFlk9IeWPiU8e+LfiVBR+kFWMtkyMEZQyR45KjzAI7ntlcJH1GJBABGRuxWAgetxJhhSrb5T6uEi4zxTJoBSroSyOCnSk7D3weAZDuveyDRilzuDConMXDhY3Q2fcsqEgrOou9FIsZEwglQkdY7keBBI9E4DMk2/+mRiIyLwUiEOg4k23ndA0mMwTPjrA0xfdlovXTa24hMG2LpyNWLBMZEogQCR9q9k8iDRqLkMCTb/GdBoocjEUdy3tpO7B5KIHfOc6ulD9pLxaLKfbqO2ABkNff95y0cUYnpnJA2u7eSwz5vcUbDmNwWPLET1TnBIfeSrgQzOJLN5HZi93DCYu5C5LmxaLx1MTjrpBQMASU5wl4nckwnyEAgKb7TiT5oJ9vz4mOPXPrZlEDG5GAlR7ObbCd2DyUqRovkUEVEIiVtIMZzaZiWENOvV4kaeTcBKWm3EnXQStRAJeo5lXA+WAmn49hL1C9AElDlubCGAjiUuXc6GheUS18oKcV8LxI9HhItdWpFCGWOGAkNvJjQM1xMBF9fTKR5LJJ1SdpKfjxlDEeSh9fh/ehK6BdcTBiLxmtQRFrbSBKtEjoQesaNp8h6lZgRlZgExDAA2KkED1oJ5zCMyW3BmE7+AwAA///Ul91qgzAUgO/3FKMX3tmcJMYkBRlW27cYYm3aSqlKomMIe/el2aYUthUZG+tFbpKTn/PznZzzSdCH0zlxnwm7lZJrtOxPQElZnIpVIlbLkBBK1zJNZAoiiVm8FOsvOxMCvwiKHbbqC9n3oPzvzkTANE4G+b/HxNZcfDImlN9GzTXY9Rok949nwVmlntusOR/c6TcnHNq2MQuEelrlG39HQHDpS9hBgFkAUEC4pTIoWE6Ugo3N8jif9/Y2ZY6+1XhfVvt5UZ9Q3pToiaBRT/Mw+iUrOm1qHWEeMMIwldy7gPVj/Rqvnnu6KXsVYfDeYym6jKPZITfZqdbOs63ulJscNrrcAncvrwAAAP//AwCN/nvXrCAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:30 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "614176afe7e8730ab594de4854b95fe7"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1744963381&engagement_id_cursor=CD67382D2915757D43E3F5F16E3CB4BD&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1745251397&engagement_id_cursor=0D5AD8EC8EB62233F9DC9D08CA5AB8F4&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TX3W/bNhAA8Pf+FYYf8tQ0d+TxS0Aw6LMYsCXF0nYPw2CotuIYiaVMktMtRf/3UbItJ00UR3Cd2IAfBN0dKZH8ifS3N71ePx4naTlI0rG9mFaXo7iM+z2n91fvm43bjDuxyaiK9DnzhIvKlcS5IC+QjGGIUgUCSCBG/bfzynIyvEyWVYYbhovAvNP5fSUlQ66N5JqrRXycZ7Pru3HUBgwHs4jnyT+zpCiTfJGjJVeGlDRSNm1k5+c2Xk6myaBIhlk6KurWlk9QFJNxWr9UmQ3OJ3lRDvLk+uq/BxVw75mnSVHYq2IwzGZp+TBetTF5LFxmZXw1WD3413hSPuhL6kX2VZbaTspn5w8v4jRNrurZ+T08O3Pf/3ryfjkNdyawKOO8ajUusrROdutxSEatuVWXdSYDJg6BDhl+ROkAdxg9UpSko9YScjj7YWnYPspZMe+qLjn9EJ48nmNbrjPOTn/7HAYtXd95s0/pZZp9TXt/JNPsJlnmxzdJbguePbBVo7PCpj0y8Tbj+9t2JSaKQgVIERNCRlopBMG8gHOGkQDjtSph21OiOQOS3JinldBOK8HmO/JMJquCl3XCwAHm8C5OqhLrROyJk9XIbgDFbiTKj3wA0j4HIiEAA4MkZGACIt4KhW8RCpOSLJMm53EoZqehaN7NSZP/GkyE6syEwZ4waQZ2AyWaGbfaQ1DqMPIiAkZSe5EOQmHIuO2HLtqqEkA0sObQtdtK9uTQVS157oDsrARpnZKT8M8dQPIzzlwQyIDLIIhCLrg0LPClXcPSCM93tafbtxKxRSRC2SYsVvEkkh0/c0FHJauCl2TCPsKcCTybybyEHNJ7spmsRnYDKH5gXI6R9MOIAow8EIqYUcglY0wY2QpFbhGKZPb4x0nwJ6HInYaiOjpRr8kEn7+bLJnwPdlN1E9A4hpjXIEQeIHrecgAoDrvoIl8dGXYjkRtEwlILRXIp/+YqJ1GImU3JE3+ayBhvDMSZvYDSTOuGyAJDApECoQUEUqB2gu1sstcuUKBUl4rEr1FJIajVnYje3on2e0jl1HdkDT5L4yEHGAOU12QkFP/9gNJM64bIFEGXE9EmodAXmQ490lHEjwWoQrRYCsSs0UkWhJIWodE7DQSxbshafJfAwk3HZFwR7D9QNKM6wZI7FJkUgDXJDDwwwABiXt+RCJiQsgfPxcNEg5bRGJ3EoPKbm57jERSNyRN/msgIeqMhPQ6JKcfwpMdUNIM7Dolvb+rxH6a/FsOrquGZ/l8Fi7K8rpwjo5ueRp/OTxnoJU5NHAOhIIAhiBH3NBQxCxJ4IsyDON3t7a3pLg8tG88nqTjd8NsehRfT45u2NHqPYtfVhMzGM7yIsuPUZFghiy9g3tal/F1YA/qRy8mt8kxwsFiMR3fX0j9i7gYTLO8ntoynyX1zaawuovw5vv/AAAA//8DADG2TmisIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:31 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "2ee0ae101b647ec41811d14be4e3b754"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1745251397&engagement_id_cursor=0D5AD8EC8EB62233F9DC9D08CA5AB8F4&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1745294564&engagement_id_cursor=425265038451DCED10143BCF45F25564&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXX2/bNhAA8Pd9CiPPLXB3JI+k30iRKgZs6bB020MfDCNWUqOJ3Flyi6HYdx/lv1kSuREcJfabkLsj5aN+4OX7T4PB2fi6KOtRUV6nh9vmcTKux2eD4eDj4HuKp4w7semkiZxRFljo6IXQyikbvNMqU+xMbh3k1p69WVXW08vPxabKCitwHVhtuvq7ZiYUxrIwQq/j1/PZ4svdOBoLVoBdx+fF34uiqov5OsewsIQktFZ2s8bs6irF6+ltMaqKy1k5qZpMsXmDqppel8sfVc9GV9N5VY/mxZebfx5UwP/e+baoqvRUjS5ni7J+GG/WmD4Wrmf1+Ga0e/Fv42n9YC8EWqffzMq0S/30gstP47Isbpbn82u8uHDvfj5/tzmIO0dY1eN5s+y4mpXLZLfsRDFpzW32XB07kHoL8i3RBzBDEEPCR4qKctJaolLVvY8j7VEvqtVWy5L3v8Xzx3PSysuMi/e//BlDy9Z3ftkf5edy9q0c/F7czr4Wm/zx12KeCp7e2WbVRZXyHjn7lPHvm3YoCEA6MEfhgIWPmgNCZJCO2Qf2rVCoXyhSWm3sXih81FC06uZkm/8aTAR3ZCKHCk+EybaxByjRGB16K5V3JmCWeoHORApJisREplWJ6FmJIUmnrIQ7KuHXVCKpsxKpT0QJP4OSTKMm46S1QBCDhuhJxzwYnWcZhPut2CmRPSphYKUso9ir5NiHLujGZFfwsk6QhkBDgg5OmhI5BPiRk/P41xEw2TX2ACe5SUowQDNlpcvDijxwnllAwMAQXKsT1acTtFJoNLjXiTpqJ1p2Y7LNfw0lQnRUIk7nNtk29hAlecwhqmhEllzEzARiF3wQvpm/JLcq4Z6VSKusPmElJzJzrZWY7krEiSh5jpnLcQbpq1VaUoaUe03RZgatCMZps5tYHyjRvSlJ10h6IdIg9iuRR60EoSOTXcFLOpEfkBsn6ulOViXyCU6OZeZ6BifpLhFeKxM8oJdkFUqB3nqNkTJHvtWJ6dEJs7EkiPfPXHzUTrTuxmSb//JKxBCfPnNtlIgT+c9k29cDkBCn7xmJyGWBBGj2zkWIFmXuc43YisT2iEQDstbyB5eJPmokzN2QbPNfAwlBZyR0fxo/UiTbvh6AxEsBJouYs8+QpRcOHaEDQ+zRhlYkEvpDIiFdkoykT3vikt2U7ApelglBM3GB7sCkKRFDdf/j6JvJfwAAAP//nFZLCsIwEN17CumiuzaTmBgjFE8iJY3pB2laklSk4N3tRy1dKW7n/+bNg/n746I/6mR7HgMDo+8+bcfKnZ1ZKL1v3RGhfmdkFuUEDlxEAnKgmFEABfvLIAnFJNEaMi4IlnE/dNPuGg2Qi8oUsWpqJNsK3QhagLrTQkyqOusam2BOGSNUEB6u9Pr2f5NsOI3uql4nGMLXMSXrQwpK6dK6sRO13nZ6Mn4S57VtHk8AAAD//wMAcF8Hk7IgAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:31 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "12"
+          ],
+          "x-request-id": [
+            "fca662d38aabb92c3b0374b5d22f4e8c"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1745294564&engagement_id_cursor=425265038451DCED10143BCF45F25564&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:32",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1745524927&engagement_id_cursor=B4308CE1F6BC164B3A1A21A0826B19D1&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+zX3W/bNhAA8Pf9FUaeW+DII49Hv4kfKgZs6bC028MeDCNWMqOJ1FlKi6HY/z7Kn1kdeREc1za2pwi5O1Km+AOPX74bDC7Gt0XZjIryNj3ct4+TcTO+GAwHvw2+pHjKeBSbTtrIBVsfiaU07IHyaIEZYu4xC4oZhbh4tahsptcfilWVRavEMrCYdPF/QyQFsiVkNMv47ax6+Pg4LtiCRbDL+Kz446Gom2K2zGFSaMlaawSv5qhublK8md4Xo7q4rspJ3WbS6g3qenpbzn9UU41uprO6Gc2Kj3d/blXAP975vqjr9FSPrquHstmOt2NMnwo3VTO+G21e/PN42mzNZfQy+64q0yTNs/Ovfx+XZXE3/zo/xqur7M33l29Wn+HRB6yb8awddVxX5Tw5m69DMenMbaecZ0qQ+jWo11K9kzAEOZT4RFFRTjpLcIj81dZIczQP9WKqecll/PXplDTwPOHq7Q+/xNAx86Mf9r78UFafy8HPxX31qVjljz8Vs1Tw7HVtB32oU9oT3z1l/PWqG4lyFPOIOsQcnAqgwBDmuYutgyzITiTycEgUCNDWMugzRkI9kdBRkdj+SNR5IKEXQOJlyC1rr0hYk2kkGbRTWfQ2y9KfvBMJHhCJlDplplfaiQRPGomAnko2Bd+SiX4HCyb0bCaLEjXcajO2mLz9KV6egJPNyu4BRUtlnVdWOJOh9MErpwXm0mTOgNdfn6sbKOqAUAQbQwLkWbdc1M/JOv8YTJTsyQSHW1vjRE+T9brugQQhl5lBGcgpRSY4K3OGdCfw6X4gDXUi0QdEIhWwBha4E4k5aSRn0XKtkXB/JHgeSF6i5dKCyUQO0dggKBqAkKvU8BA4g+lM6URCB0Si0WojU9ZOJOqkkQjAfko2Bd+YiWqZoOjDRM1brn+9mZxMy4X7Q3HWGpsRieAzAOECS9SKYnQh88pDJxRzSCikwZBluxOKPmkoxvRzss4/BhOlezMBeSZM1gu7h5Iovc10Aqd8dCylcD7zmUad9JDPu48TPqQSjYgG1e6Lyf8914sp0b0uJmrec5n/Ts8VKU8XkcA2aozB6iAyq5WLMe1UJpd3IrEHRMLM1jCsLz/neJQI0bfnEkfqubjd8wB9mHB7mJzL1WSzsHs4IRMoogKDuTCkCILXzmHax2hYONHlRMMhnZBNI8B6jHM8TFj0Y7LOP4YSYXorQT6Ckr8BAAD//5xXSwqDMBDd9xTFhTvNJFVjCtKTFIlp/CB+SGIpQu/eqK3iSuh2/jNvHsP8wZJ1rkckOd8nQ6eVL5P2U+BBLSCUxvT6itB4aXnm5QRiyjwGOQQ4DAAERA97N0TIiZSQUUYw90ebTerasx0XVVv4omsQ7yv0JGjrU982XFIxKN2pBFN7oKIYM+ruyPrTH/HVnUvX1SgTDO53l5L9Hjkl12nTqRlZowY5C1fH5Z07vT8AAAD//wMABZvCxK0gAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:32 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "11"
+          ],
+          "x-request-id": [
+            "ccb282eedca9e5d4f4347335515866df"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1745524927&engagement_id_cursor=B4308CE1F6BC164B3A1A21A0826B19D1&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:32",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1745568197&engagement_id_cursor=67D6E34073F176460DC5BB33093781B1&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SXTW/bOBCG7/srjJxbYMjhx1A3SiKLBbZpsdmPwx4MIVayRhOpteQWRbH/fSk7lr2J5Y3gyLEAHwjPOxxqqEcz8+OnyeQiu82LepoXt2Fx3yxnWZ1dTKLJX5MfwR4UO7b5rLFcOK+lNEDGuwQMMR07YVXseWIZl3F88WbtWc+vP+UbL4NGsgfDOuj6f60UZ0hGIaF+sN8uyuXnXTsjAwbBPNgX+ZdlXtX54kFDSggShKhUu0d5cxPs9fw+n1b5dVnMqpVyc4Kqmt8Wq4eqy+nNfFHV00X++e77Ew/4z5nv86oKq2p6XS6L+qm92WO+z1yXdXY33R78Wzavn8RSm+PdlUUIUj9bf/13VhT53ep23rurK/vu58t3m2vYucCqzhbNrllVFiuxXeUhn3Vqm5ArJQcu34J4y+VvQBFgxOUep7yYdbqICPHRqxFi1MtqHWrl8uGju9yvCTuvFFcffvnDpR2hd57s9+JTUX4rJr/m9+XXfKPPvuaL4PDsxDabLqsg23PxQfHPm25KBHobMoCKmRSVlBgIsSz2OqUYbWo7KeHDUSKZFAQQKD1ICZ41JQygHyZbh9NywngEPJLYg5PGZUScbDN7DChCW+NEeH29S2OBiUuUZt6p8EVnFnwnKDggKGA0lyiBHQRFnjUoWvTjpNWfHhOMQPXGhMP/YXLp/jwDStq8HgEJ9yplXHvHWcgDJy+ls97oVBkygZJOSMSAkDA0oIxUh6uJOmtI2sM/t+eSrwgJ470hYXockLR5PQIS0InVKBRx5lFZoUNVAcsteaDEM9UJiRwQEsEE4yRbzX5IxFlDwqBnKdk6nBgT1Xs0aVxkBGY0LdcLVBOE0FxRTAxMHEoJN9aaOA64oDHGpq4TFDUkKCgEl4YOt1znXU206sdJq38NTAT0xERE8vE39EyrSZvXY+YSpQVXZCnmzHiZJCi9JpFwERvjPXVCogeGBIURhyHRZw3JWFquNSS6PyR8JLXkJXouyxRhAqlKyVkNzrPU8DCYUOpC0xU/TsWWEhqQEqU1Aik17p5L98Nk63BaTjhEwHfmjGdw0riI8BsJJ9vMHjOcOHIJScVknDohYkpjgdqhTzhybmUnKGZIUEJF4aHrwjH3XD050a+JCYqemGAk2Uh6rheARIRXmlkOVgtEAJmgJeMDIwmmltLHH4wWEgUDQiIRFXGEUfdcPQcT9TqDyRqSXoPJGhJx+sHkXwAAAP//nFfJCsIwEL37FdJDbm0madoaofglUtKYLkgXsogU/He7qKUnxevsjzfDzPx3cv36mOzPk6HXqrvN+imw0wsJlbW9OWI8hK3I/YLCIeE+hwIYiRiAhPgSciYjQZWCPOGUiGAYsylz9UfEZd2WgewaLPoa3yhecZrTyksmnTadTkky7ghCwhjQZljf+m/ziubSTT2olAB69VK67SOvEiZrOj0za7VTs/DjuCzg3eMJAAD//wMAhglboa8gAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:32 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "8e32ba2e9ce2f8f74ff61da4626b764a"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1745568197&engagement_id_cursor=67D6E34073F176460DC5BB33093781B1&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1745611360&engagement_id_cursor=48961A20A7433005C3A89F3FCC3DA8D4&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXW2/iOBQA4Pf5FYiHPg2D7ePbQRqtcnFGK+12Vtu9PKxWKAMuRS0Jm4TObkfz39cJEFpaaCNEGx6QInyOnRzni+1v7zqdbjyxSTG0ycRdzMrLcVzE3c6g81fnm2t3EffapuOypRvI0KBSkfIMR8GFIlKYKCAYIkAU0u77ZWYxHV3bdRYCSrpqWA66/F9JySholKBBrdonWbqY32+nGgkCwVV7Zv9Z2Lyw2SpGSy40IcA1MrGKSS8vXXsxndlhbkdpMs7LSFjfQZ5PJ0n1UEU6vJxmeTHM7Pzmv0cZ5ME9z2yeu6t8OEoXSfG4vexj+lRzkRbxzXBz41/jafFoLErW4Tdp4kYpXp4wuoqTxN5U8/OzubjwPv14/mk9EfemMC/irOw2ztOkCvaqStjxzthyzCqSESZ6hPeY/I2QAWEDLp9Issl4ZwofMLn1crgxikW+HKpK+fyLOX86xvVcRVx8/ukPE+4Y+t6T/Z5cJ+nXpPOrnaW3dh0f39rMJby8smWvi9zFPTH3LuL7+z1QFFLlEeoZqRA0VUwrzThgxHw/8vlOKOyYUJQkQoPcD0W2GoqGZk7q+NdnAgNCmjOB55icmz9boKSu6wFIvMinKjABRJqBoYbJgHsBFZFxawnXu5HAMZGApG5ZY/SEkdTCX4ikjn8TJKIxEkpOA0ld1wOQoPI9A0QAN4YzpEIp6nFfgwiY8PTuLRc/HhJJmObUCd2/kvBWI6GMNVOySXhlJrzcclHWhAmvmGx/QVu75aorewAUHzRRgEKFXIWA1C0kYSA1Up8YjeDthCKODEUo4PtXE91qKBqbOanj34IJ0MZMyImsJnVdD0ASaQylw2Bo6NOQAEfmB+gB5T4qY4KdSOSRkShwXZ0wEqmaIanj3wQJNkQCAy5PA0ld1wOQgOdJE2lJAELlMeMRZSj13U8gMwR3IlFHRMLQLWJaK7UXScu3XIQ3U7JJeGUmuvmWS5dMxIkw2RT2ACfC5+59BCIxAC7dlsuAW0bcuQR1IAO124k+ohOqEJhw56W9TkSrnSjZjEkd/xZKmGyshLPnlLTkYFIX9hAlnmJhyAWGmhMMqCtGIFUoQdLA+GL7jLZRgkdWAow/s5qoViupD24v3XKJN1QC0FgJ6BNRUhf2ACWU+B6LJNcyNJS54wmCIhhy5mvAKNr+YNRKFDmiEi44VUzWEp9WAq1WcjJ7LspKJ0Q0cFKmuNVke6PRVicv33R1/i4Du4n9txjOy54X2XIaroping/6/TtI4i+9S0a0wh6SS8Kp4ISMiBwD8pGImbXki0JG4w93bjSbX/fcI0+myeTDKJ314/m0f8v6mwfNf9jMzHC0yPI0+0gVF1JqZOLsAdi6/RmzZ9Wt59M760LPVm/Tx4dvUvcqzoezNKvmtsgWtvqzTlyW7d33/wEAAP//AwCi3sklsiAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:33 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "f0f570a93bbc596243cac93acbc6e57b"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1745611360&engagement_id_cursor=48961A20A7433005C3A89F3FCC3DA8D4&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1745668925&engagement_id_cursor=10BA2F6486DE12E1D93709D42B839FF2&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SXS2/jNhDH7/spDB9y2mw4fNNAUFAitSjQZotmH4eiMLQ24xiJpVSSs9ss9ruXkmM5Lz8E17EMXwTPfzjUkD/NzI83nU43Hrmk6Ltk5B8m5eMwLuJup9f5q/PD273igW08LC1doxXjNLABo4GUEHAZYEuJ4BhsSIF33848i/Hgys29FFEC7g2zoLP/BfduRCpOJBH39lGWTm8e2kEqpAhS9/bM/TN1eeGye43klFPCFRAh55r04sLbi/HE9XM3SJNhXir5fAd5Ph4l1UsVaf9inOVFP3M31/8+80CP9jxxee6f8v4gnSbFc3u5xvglc5EW8XV/sfFv8bh4FkvMt3edJj5IsbF+cBknibuuTud3e36u3/969n5+DA8OMC/irFw1ztOkEusqD264VFuGrJQYYXaM6DHmHwH3EO5h9IKTS4ZLXUiPPL0aPkYxzWehKpcz++VliV+4Epx/+O2zNUsiP3ixT8lVkn5LOn+6SXrr5vr41mXeYeO8lotOcy974dy94ufb5ZBYHiDNI0MDwUIVWswN5lZjYWgoNVFLIcG7hIQrCQRAHDAknDWDpNbvBRLeHBJYB8mHP+xZCyipE7sFJQypEBkTRBaDZ0UyYiOCaECJZVbb5ZSQHVLCmf9hgmAlJbTVlCjVjJJa/8qU8PLKI2hCiXehPYoOhJI6sVtQEmJkcBCFAQ6YRNTfX8ZDrCiLVKBNEC6lhO6QEuH7LaoUXd1wsVZTUido04aL7pESoI0pwfJAKKkTuwUlRAuDLDAF1jKgMgxDbWQIgBTWVD39YCwoYTukhAMHRghdXUta3nE1pITvk5JmY8mMEnoglPD/gRIhA8QlM4aqiGmsrbGRjkBzCgwJ+XRCW1DCd0iJryR+CbFmLml3xwUAzTBZOLwuJxhVk0mTnqt0oT3AB8LJIrNbgAJGMGyQRsAjpii3VPtLLBgYroUW0VJQxA5BkRR5ejliK0ERrQZFomac1Pp9YEJkQ0xIj61tus7slxZQUud1m8lEqcgaX0QAQqUFsCgKlcDIioAZbJdXE7nLaoLLcgJ8NSSy1ZBw0QySWr8PSChvDgk5kFpSJ3YLSqhnRDIZ6RCZUEfMWI6pv8sBxkwK+TQVC0rU7igRXgNACVo9mZBWUwKINMNk4fCanIiPqOIE4Y05mbmQHmWHUUwWid2CE0WJb7hMADxQWknKQRjEcaDBGsrN0pZLol1ygiVXRLDVswlrNSf18LYhJrV+H5TA5tVkTglZO5m0g5I6r+sg6fxdCruJ+170b8qFp9nsEC6L4ibvnZzckST+enyBkRTqWKELRIH52WCA+JAoOmAxdg59Fb4Vit/d+Wguvzr2bzwaJ6N3g3RyEt+MT27xyeI9818W59IfTLM8zU5BUObvPxB+9AjWuX0dr0fV1vPxnTsFdHR/l04f36PuZZz3J2lWnWyRTV31Z+04+7a8+fkfAAAA//8DAKl8KomtIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:34 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "12"
+          ],
+          "x-request-id": [
+            "b4c2019611f449f01aa5f710b067177e"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1745668925&engagement_id_cursor=10BA2F6486DE12E1D93709D42B839FF2&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1745712136&engagement_id_cursor=943D0ADB16B9A984617D062BA1ED46DF&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SXTW/jNhCG7/srDB9y2myG36SBoCAlalGgzRZNPw5FYWhtxjESS6kkZ7dZ7H8vJdty0kSOBcOxfJM973DIIR/MzLd3vV4/nrikGLpk4j9m5ec4LuJ+b9D7q/fN273ikW06Li19FoIwgANAGhEDFmgkJYiAkEghDUH//cKzmI5u3MpLESXR0rAIuvhfcI4RkYoTScTSPsnS+d1jO5IKFAG1tGfun7nLC5ctNZJT4TVYUAKrGOnVlbcX05kb5m6UJuO8VPLVDvJ8OkmqQxXp8Gqa5cUwc3e3/z7zgCd7nrk891/5cJTOk+K5vVxj+pK5SIv4drje+Jd4WjzfHVuqb9PEBym21o+u4yRxt9Xt/GwvL/XHHy8+rq7h0QXmRZyVq8Z5mlRiXeXBjRu1ZchKiQGzU6CnWPwGMAA8wOQFJ5eMG13IAMv/PQ0fo5jni1CVy6df7MXLGr9ypbj89NMfNmwI/ehkvyc3Sfol6f3qZum9W+nje5d5h60TWy46z73shYv3iu/vmykhxjJOrNTMv03LSWRpSCUQ/0txFplGSvAeKSGYKkmwIhspIZ2mBAFth8na4Y05oSUn0IoTWnJCxWucXNg/O4DJOrE7cKI0txASLpniRlsRipAHQBmLLBYRb64mZJ+ccI4YonhzNWGd5kSIdpjU+kNQgkRrSgg9kmpSJ3YHSjAyWBgqDcPAAqWlABkIK4KIhaHUtpESuk9KmKQKU7S5mnS85+LtKKn1h6CkXc9VUYLVcdSSOq87QMIhCiGMKMWaynImMRIrQBaTwBrzLBNrSNgeIWECA0gmNkPS7VKCasS3bblqhzfGRFbFhLfBxLt4Uo4Ek3Vid+BESqEM8q9XaMx9r4Moh1ADNYLoCEfNxYTvmRMihdzccolOc1JvfktMav0hKFn3T1tSQgaMHUnLVSd2p8EENFcqEkYhywJicBgYGxklgCgdmEZKxD4p4YCBCySOmBIuW7Zc8oCUUNSaEvpqLekIJXVid6klGAUhDSmWVgdahJxGVmjGFWaBDSlppETukRLBBVOAudpICek0JQhwy56rdnhbThAuOQFowUnp4jnBR9Jz1YndgZOAh7KcAgJmKQ08Lcj6aYUEikc4pLy5mqh9cqKIxBSzY55NBGuHSa0/BCWoTc+1oOTZ2NpRSuq87gAJIcg/RxFYZQxYroHYSBtQSEultY2aIFGwZ0hIWc82QsI7DQlvCQk/JCS4fSnBrw4m3YCEbwtJ7+9S2E/c12J4Vy48zxaXcF0Ud/ng7OyBJPHn0ysMUqhTBVdAEaMAI+BjouiIxdg5+CwURvGHBx/N5Ten/sSTaTL5MEpnZ/Hd9Owen63Pmf+wvpfhaJ7laXaOBGWCMULh5AmsK/trvJ5UW8+nD+4cwcnyLZ0/fUf96zgfztKsutkim7vqz9pxUYDfff8PAAD//wMAglWKUq4gAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:34 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "13"
+          ],
+          "x-request-id": [
+            "f4906337f36de16ff2920a94b48fac17"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1745712136&engagement_id_cursor=943D0ADB16B9A984617D062BA1ED46DF&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:35",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1745755340&engagement_id_cursor=3312427CE9BB0E6A03EFAB091A89AAEF&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+TXS2/bRhAA4Ht/heBzAszuzL50W+4jKNA6RZ20hxwEwaJdITaZilSCIuh/71JPxxZVEw5tEfFJ8MxwqeV+muHXn0ajs+l1XtSTvLhOH26bj7NpPT0bjUcfRl9TPGXcic1nTeSMvGFOe2+dlj4TQlnGgndRSKdCIHH2al1Zzy8/5tsqg8awTWC96Pr/SkrOUBuJGtUmfr0ol5/uxpk2YBDMJr7I/17mVZ0vNjlakgammRSocJNTXl2leD2/zSdVflkWs6rJpO0dVNX8ulh9qbqcXM0XVT1Z5J9u/nlQAd/c821eVelTNbksl0X9MN5cY34oXJf19Gayv/Ev03n9YC2z3YCbskiL1I/Ov/xrWhT5zerp/BouLuybn8/fbB/DnQdY1dNFc9VpVRarZLvah3zWmtssucrkwMVroNdcvWNyDHwM6kBRXsxaS3BMdO9opDXqZbVealVyHv48nJIuvEq4ePvLH8G3rHzni70vPhbll2L0e35bfs63+dPP+SIVPHpfm4suq5R24LmnjH9ftSMJ0Vkvo0drlQ/KhoQFQWZBSaRkpRUJ7xMJkgRJkh1FIk4ayU74I5Hs8l8CCTOdkSAfBpLdvj4BCWWKMkcW0g83eTSSeWCkSHHOgzbYigT7RAKacZHayYCRSNENyS7/JZBw6oyEm2Eg2e3rE5CgsyaNW8RMpCA4d1lqEtai0tpJ5XUrEuoRCQcQKYUfR4InjYSB7qZkX/C8TDiMgY1Fl4GrKUkD1/0x40SZ7Df2CU4YqCi9lIx5wWV0oDGi0BBcTGdZQqsT0acTDYo4sOOvJafdTAYycTVHvuPEtVbyI01cToPxRmFGMkTjBTjGvRPaGZTprMpWJLJPJERMaMXUgJEMZOJaI+k0ca2R/FATl5YO08AVmDPcWS3BaLTpjCqnhNLUikT1iIQMM83fcSR00kgYsG5K9gXPyUS/g3UvgUczWZfgWLBhMNlv7BOcRObS60hMHYRnisgDZBSZ1pmk4KW9vxV7J7pPJ8QkEnFz1Ik8aSeqYzNRL9FMtko6NJOtEhxIM1HfoZkkDzqDYNFQgsEiyohcCIeRPLf2/uy5R2L6RmLYrlkOEckgJq4tEuzeSlD8H5K3v4XzE1DyPUYuY6MjxwkEx6i09lHE9JJiXdBZZrw/rIQAoEclWiNLQ9/uvWuYIxd1Y7IveGYn1Bx66NRMUgmNSb+Mk/8AAAD//yKjzWVCZEZRiAUpVMpLrSiJLwCZXFoEiYaMkpKCYit9/SrjvMQk3TQjAwtzS11LgzQDYOcEmBmSDcxSgPVMsmmiUWqqQZK5pZFhol4V0LbU4mxdoJfTM/PS9ZLzc/UTCzL1y4z0ER4ttkfETHxyaVFxfpGtobmJqYWhkaWFiRpKhoXJE8qzamCnF2dWpdoaGqhBU5MtakpSykgsjs/NLwLHbUlRaSpYEK4REmxctQAAAAD//wMAC5UmXKwgAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:35 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "28a250df4b9121c47db07f50395ff310"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1745755340&engagement_id_cursor=3312427CE9BB0E6A03EFAB091A89AAEF&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1745812984&engagement_id_cursor=9AFC4C240523F788DF5F3B4ACE8BB9DD&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXW2/bNhQA4Pf+CsMPeWrqc3ingWAQKakYsKXD0m4Pw2CoNu0YiaVMktMuRf/7KDu2c1MawXNswS+CeQ5JkfxE8tubTqebTFxaDlw68Q+z6nGUlEm30+/81fnmy33EnbLpqCrpWgQIY0qIYlZLqSNltTVGBRq5iAC7b5eZ5XR44VZZmgHgbcGy0eX/UgiCVGlBFZW35ZM8m1/dLUelQVPQt+W5+2fuitLltzFKMKUk55wSuaojG499eTmduUHhhlk6KqpIsepBUUwn6eKlymwwnuZFOcjd1eW/jzLgXp9nrij8UzEYZvO0fFxe1TF9qrjMyuRysOn4l2RaPmpLrrp3maW+kfLF8cPzJE3d5WJ2fo3OzoL3P5++X03DnQksyiSvak2KLF0EB4txcKPa2KrJRSQBwo+BHRP1EVgfaB/1E0kuHdWmsD7lD5aGb6OcF8umFimn0Z9Ph/iKFwFnH375IwprWr7zYp/SizT7knZ+d7Ps2q3ik2uX+4QXj2tV6bzwYU/Mu4/4/rYeiVacKxZTJSiHkDJlqUROA/BY4iCKapGQXSKh1McgthmJaIhE7BMJ4c2RPPx+HigS8T8gIdIwZBiBNJEFqhhaJBSMJAJCMLYWCd0dEk0IeIXA+LNI+EEjQcKaKdkkvDIT1QfS57QJE1Ux4fJHTD78Fp0egJPNyG4BxUR+VXJmwohIHoTS+LMWVTKQsYi1JUEtFLZLKMCYQOD0WSiIBy1F6WZQ1vGv78RvJ9DYCdPt2E7W47qFkkihMLESWgQ2UgFXNAYSghCAfr1jWKuE71IJ+vMWaIbPKyEHrURCMyXr+H0ooaS5EtIOJetx3UKJsibmsd9BdBiyQPtripAKPZvQWAjCh8fPjRKxQyWMMaTM96PNhy7AZko2Ca/LBEl16ALVgEmVQluzmWwGdgsnsTUo0UgJgRUy1MRoEksk6J2gZabWidylE04IByVli51I0YzJOn4fSgg2VkLbcjVZD+wWSoiRwGSkrV/cxoaIWsaURQoUpZGMeK0StUslijOCQj9/MxEHrUTwZkrW8XtRIpsracmRaz2uWyABbaSy0vibgCZCxoJZf+zybBRjFCNVi0TvEIkE6fcS3fIjl2qmZJPwykxE881EVDcTaM2RS23vxHMQ1lKtOVpi0P+o1TbWIYLfVqDWCcIOnQgF1FcBzzuRB+1ENmQi96mENrqYiGoz4aItR66XKun8XQV2U/e1HFxVFc/z5Sycl+VV0e/1bmiafD4eE38Z0McaxsCQ+x1jCGJENRvyhDgHn/1+g8m7G9+aKy6O/RtPpunk3TCb9ZKrae+a9DbvWfy0mZjBcJ4XWX6CknHFBXJ1dE/rqvxHYI8WXS+mN+4E4eh2MZ3cX0jd86QYzLJ8MbVlPneLP9eJy4/Lm+//AQAA//8DACHRAWSvIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:36 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "12"
+          ],
+          "x-request-id": [
+            "8074753c4757de3243f919f052afbd6f"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1745812984&engagement_id_cursor=9AFC4C240523F788DF5F3B4ACE8BB9DD&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1745856158&engagement_id_cursor=8446CC39951C2B1B1B3C9CF9D1097F08&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+TX3W/bNhAA8Pf+FYYf8tTUx+N3gGCgRKoYsKXD0m0Pw2CoNuMYiaVMktMtRf/30fJX0kROhNSJjb3JvjtSIvUDT1/edDrddOSzqu+zUbiYzC6HaZV2O0edPztfQjxk3IqNh7NIlxFBY2EUlTRCI2JMCCATlFrFDXLbfTuvrMaDC7+s0gwIWQTmk87/l0IgoUoLGsZbxEdFPr26HSdKg6agF/HC/z31ZeWLRY4STAsFlKNYjZGfnYV4NZ74fukHeTYs69GWd1CW41FWP1SV98/GRVn1C391+e+9CrhzzxNfluGq7A/yaVbdj8/GGD8UrvIqveyvb/xzOq7uzSXEIvsyz8Ik1ZPzB+dplvnLend+dqen5v2PJ++X23BrA8sqLWajpmWe1cmmXgc/bMydTVlnIiA/BHaI6iMRR4BHjD9Q5LNhYwk94uSbVyPMUU3L+VR1yYdf3MnDOWHkOuP0w0+/O9sw9a0n+y27yPLPWedXP8mv/TI/vfZFKHjyws4GnZYh7YGNDxlf3zYrQTSQOGuUjISGGBR1INBJnXBuif12KdZKcItKNCOUIpObldCdVkKAtGOyLnhZJwgzJ6BbOJmVBCewJ07WK/sMKAy11CyxjpBYKu0cOCmMNFZapQREjVDoNqFIJIKFrI1QxE5Dkaydk1X+azBB2poJlY8xOXF/7ICS1bo+A0lCuXRUJpxyzTVxkbEsik0kuVUMjGpEwraJBKWUAvlmJHynkQjeDskq/1WQqPZI6H4gWa3rM5BwtBYZgKSK20hE0iiLwQiJYya0SxqR8K0h4UAUQUSOfCMSttNICLRUsi54SSb6I7RtueYloeVie9NyfQcoCY1iLUxkIQzHDQ+ni+VOg+IMkiTBRihiu1AoAUr3uuUS7Zys8l+DCbLWTNi+fJmsFvYZSohlGNqbSFJUsUuM5YyF38ASDlJS06hEblEJAiCG7yKyUYncaSV70XMtlVBorYTy/0/PpROeEBNDeGtRMqoSo6UhhijOGYm0aESitoiEhSaQS602I6E7jYQAtFOyLnhhJmzGhLTquVjdc+k9OUzWK/sMKAJDj4URc1HMFVfKaSIBpY2tUchd1AhFbxMKUgVKrMZ4GArfaSiy5WkiX+k0qZlQbM2Eyf04TeR3OE1iTTnGghKMQIpESaGpSGziqOTUOdWEBGGbSMJpothjLdduI9mXlmuORLVHQvcDyZNbrs5fs8Ru5v+p+lezgafFfBPOq+qqPOr1bmiWfjo8Q1BSH2o4A0Z4eFEHIIZUswFP0Xv4JDWS9N1NmM2XF4fhiUfjbPRukE966dW4d4299XOWP6z3pT+YFmVeHBPJuNIBpTq4g3UZf8zrQX3r5fjGHxM4WLxLx3ffo+55WvYneVHvbFVMff3nqnB+AL/5+h8AAAD//wMADykI1a8gAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:36 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "12"
+          ],
+          "x-request-id": [
+            "667061178accc8b4c59e690b159bca28"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1745856158&engagement_id_cursor=8446CC39951C2B1B1B3C9CF9D1097F08&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:37",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1745899358&engagement_id_cursor=C9352C6312B076F876936FDFE3753EE8&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+TXS2/bRhAA4Ht+haCDT1E0+94RYBQkdxkUaJ2i7uNQFAIjrWTBFumSlJM6yH/vknr5JTmEIltCfRBozQyX3OWnHX5502q1k7FLy75Lx/5gWh0OkzJpt3qtv1pffNxn3IlNhlWkrbWJgFgbGhXFCowwNJIcNAoehjGj7bfzynIyuHTLKuRAySIwH3T+vZKSEqZRMs3UIj7Os9n13TjRCMgAF/Hc/TNzRenyRY6WArRgklKll2Nko5GPl5Op6xdukKXDosrkyysoisk4rW+qzPqjSV6U/dxdX/37qALuXfPUFYU/KvqDbJaWj+PVOSZPhcusTK766wv/lEzKR2MRJhbpV1nqRym/vWBwkaSpu6rX52d7fh68//Hs/XIh7ixhUSZ5ddqkyNI6Oahnwg035lZj1pkUqOgA71D8DXQPaI+TJ4pcOtxYwntCPng4/BjlrJgPVZec2T+fTvEnrhPOP/z0hzUbRr5zY7+nl2n2KW396qbZjVvmJzcu9wXfPrHVWWeFz3ti6X3G17fbnEgVaRGHHCBEoqgGbTEmCoFLaoKNTug+nSAIXeVudULIQUNBbOZklf/yTFgPsDETrp9j8uEXe3YATlYTuwMTjgypCG3ktxFNwhiFopGNkJqIChNtZsL2yATBfyil2HYm9KCZKGjGZJX/Gkxo892EkSNhsprYHZiQiBurRKCMQiTEams9Aqm05VqF2m5kwvfHhPgk5IxIsZWJOGglBGgzJuuCl3VCaNV1UWjgpCrhvupInKxndhcogQ6UfzCpoVoyBtxSzUJqSGCN/09shCL2CYUSrqq0rVDkQUNRspmTVf5rMGG8IRPWE/Ack8N4OVnN6w5IBLcMrDICDIaoeByx2Pc7EcrARwLciETuGQmCJ3rESGRDJPI1kfCmewnrcXkke4n8DkpiioaRIJYSQ220VSDCSAOH0BrfiT38vVgrUXtUIghw9J9qqxJ+0EoIsGZM1gUv7ERWTkgjJ7LeTNiROFnP7C5QeMxARwHTfgux1moexxGPNUDk/+zmnkvvEQpHqrWSajuUw95OjqXnqpnQRj1XzYT/j3ouw0MbSxCxt0FjbYx/PQl1SGKiuEL6cGNdI8E9I0Gh5TG/mBxLzzVHgo2RsIe/nweK5Hu0XAIopyoMjKXEMrTaMgIxj9A/7USqcBMSBntEoggoqjRsfzE58JaLkIYt16rgZZlQqJiIJi1XVcJ7nBwHk/XEPuek9XeV2E7d57J/XZ15ls9X4aIsr4tet3vL0uRjZ0RBK+wgjIATwQEGIIcM+UAk1Dn46DcXkry79aO54rLjb3k8ScfvBtm0m1xPuje0u77R4of1wvQHs7zI8lO/PQkUEhWc3PO6jD9H9qS+9GJy604JnCweptP7D1L7Iin60yyvl7bMZ67+clU4b1TffP0PAAD//wMAzkhbCrQgAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:37 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "a4c343114ef77b63cce944c94d7eb88f"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1745899358&engagement_id_cursor=C9352C6312B076F876936FDFE3753EE8&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:37",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1745956970&engagement_id_cursor=502427BADE21E39E8E310F4C9213167B&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+yXTW/bOBCG7/srjJxbYPg99I2kyKJANy027e6hB0OIlazRROpacoui2P++lGJbqRO5EVzFMrAwYAuedzjUcB7N6Ptvk8lZep3l1SzLr+PFbX05T6v0bDKdfJx8j/aouGdbzGvLmaeOymC0Tyzl0mlmCGUYpPbBOUPs2Ys7z2px+SnbeGkOjKwNd0Hv/ldSUsJQS4ZMre3Xy2L1+b6doAbNQK/ty+yfVVZW2XKtQSmIIqBYFG9iFFdX0V4tbrNZmV0W+bxsVtvsoCwX13lzU1Uxu1osy2q2zD7ffHvgAT/s+TYry3hVzi6LVV49tNdrLB4zV0WV3szajX9NF9XD3W1u8KbIY5DqyfrLv9M8z26a0/ndX1yYV6/PX22O4d4BllW6rFdNyyJvxKbJQzbv1NYhGyUFKl4Cf0n1ewpTYFPQjzhl+bzThU8p7pRGjFGtyrtQjcu5/+txSVy4EVy8ffOnTzoi37uxD/mnvPiaT/7Ibosv2UaffsmW0eHJea0XXZVR9si5R8W/L7ohEdZoG6QPxhEHEOsTCdeOQ4KeU2c6IaEDQiIRpOLAxV5IcNSQSNkPkq3+GJAQ2R8SehqQbPN6ACSYyEAiDkIqL4UmIIKnKgQRFFFB805I2ICQaEWI1JqovZCwUUNCoGcraR2eERMG7yHWPJ2SJ/eStQufwk97ydt3/nwEnLSZPQAU5oRIFFBkce7i8SO9lNZTm9QDGHSPXHxIULjAyK7YD8rIRy7sx8lWfwxM2JO7ydqFTcXuM3SsmGwTewAlidDgvadoOLWYIDWcEE6sjqVu0ehOSsSAlKAigjHOTpmSU5i5tpRw1psSvlsaY6XkVwxd1ngrgUhCiLfKIsZvTMAkXjMKbrevtpTI4SiJa3CtKUNy0kNXT0xah2fmhNecQK+hizfdRJzGu0mb2AM40VKaoJl3MhZmoo0wggUvIL6aOOpUdzdRA3JCaRy6GPykm4hRc6JUP0y2+mNQQnlvSjg5kW6yTewBlDiUEhU6R40JApG5ACYQbqzR0iXd3QSHpCS+dAkKcn83kaOmRPakRB6TEga9KWHqNHqJ/AWQaMuYEsoG7om2hhgiFI/txRrntPG7z4sWEj0gJAI40ZQKtheSsY9crB8lrcMzY4I1JqQXJtiMXOw0MGkTewAnCTpwwclYuILRBCMjQscfIzRVBGwXJxyG5IRShcjV/yPXM1HSb+TCY41c/wEAAP//tFZJDoIwFN17CsOiO+hvKWJNiCcxpNQyxDCkgzEk3t0CKmHlyu2fX96f/vty7S+TYdCph82HKbDTCwu1tYM5YTzGnSjCksIx5SGH0m/zhAFIOFxjzmQiqFJQpJwSEY0+mzK30COumq6KZN9iMTT4TvGK05xXYnLptOl1RvyZAgDCGNpM60f/a2DRXLppRpURQO9myraNFNTC5G2vZ2qtdmoWfh2X5bJ7vgAAAP//AwBpESC1ryAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:37 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "88ea2c20767657cc4b8f9a4508c07ea2"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1745956970&engagement_id_cursor=502427BADE21E39E8E310F4C9213167B&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:38",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746000144&engagement_id_cursor=D8C0CFC6309532D846659D84A592710B&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SXy27bOhCG930KI+sWmOHw6h1JUcUBegGaXhZnYQixkmM0kVpLblEUffdSiiOlSZRG8FFibwzB8/8caqgPM/z5bDY7ys7yol7kxVl8uGgel1mdHc3ms39nP2M8Kq7FVssmckRemoRCIhi3inlQUoBQQtgUtTVKHD2/dNark8/5lctw4LgNXCa9/F9JyZC0kaRJbeNn63Lz5XoctQFDYLbxdf51k1d1vt5qtIxb0WgQTKcpT09jvF5d5IsqPymLZdUoEa62UFWrs6J9q7pcnK7WVb1Y51/Of9yywB+bvsirKj5Vi5NyU9S3480aq7vCdVln54t+59+zVX0rl6St+rwsYpL6wfqT/7KiyM/b43kdjo/ty3/evLw6h2snWNXZulk1q8qiFdu2DvlyUNukbJUMmHgB/AXBe9BzYHPid5jyYjlooTmpG99GzFFvqstUreVN+HS3JC7cCo7fvvoYkoHM117sQ/G5KL8Xs3f5Rfktv9Jn3/J1NDy4rs2imyrK7jj3qPj1fJgSFZySNvHaKpSSG86kclY6ERKWIE8HKWETUiK11AhaqXsp4XsNSdz/OEp6w+NigqzBBNkITBoLnwMcBiZ9YXfgJKQpC4YpjsJJYKmynrvUawyUgvd+kBOamBNSjIt7OVF7zUkH+QMx6fRPQQnBSEpozg+kmXR13aWZgLVKGq0JUuIcGYvtBVBrzq1Xjg9CwieERCmhSQi8v5novYZEypETl3xKSNR4SOgwIOnqugMkQgvLE6tIOgSBjKfSB+9T41OWOLKDkIjpICGAeDWRf7uX7PvEheMo6Q2PjIlsMAE5BhN5SL2kL+wOnKBmxgbHBNdEaFBxoGBM6sAnicHhZiIn5sRw9ZdmIvaak0OZuFpKUI+mhMRhUPJ/TFwukGfkiZR3ykmJLmAiUDoujAF384bWQ6Kmg4QZoxGZkod8Lek2/9CJSzwhJEyMh+Tmp7GnkHR13QEShkonDAKYIEix+JNIFIkSyqMHkQ5CoqeDhFCTFkZovBeSPZ+4mB5HSW94XEwYtBMXjMCksfA56J0xScKr8H76kaur7A6g+DQNznGLPnU8BLDkOGgrnHDk0nCzr/agmElBiW0N+zUOceTSfBwnnX46TH4DAAD//9SXzWrDMAzH73uK0UNuqWXLsetBGCHeY5TgZm4bRpNgJ2ME9u5L0zalhbKVskOutvwh//WzpNuYULwTkz6bTKQxGd/1AUhEqhNIKE0EExq5TiXwFKXSb7onIbn+MEZIIvhvSLgabaYIyURKriMk9/QlB0gYTgOSP5dcz8u94ay0X01W7zdu3UGEbdPU/oWQDkuzCtcMFlKFCtbAacQBchDvqHgeGWYtrKRi1My7/jTrP8Le401RbuZ5tSOmLsgnI2c//etZlyxvna9cTCUXwBFxEVzAepr/jddguLovOhtTCI6xFF/G0WxrfLar3KBs41o7DI4LhwQMT98/AAAA//8DAAp9LmCsIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:38 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "5ad3ef6a282e028789ef177c55c5a50f"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746000144&engagement_id_cursor=D8C0CFC6309532D846659D84A592710B&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:39",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746043338&engagement_id_cursor=6CDA0A11A626D34DC704C379DED404A8&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+zXS2/TQBAA4Du/IuoZpJl9b2/78CIkKIjyOHCIrMYtEa0NsQNCiP/O2kma0MZpLeLWkZAq1erM7Dp2vs7sryej0VF6keXVOMsv4sVVfTlJq/RodDz6NPoV4zFjIzad1JEjaZEY5ri2IL032nhmSAgAiQ+EoDh6uqispmdfslWVZsBxGVhsuvi7FIIgVVpQReUyfjEr5l8346g0aAp6GZ9l3+ZZWWWzZY4SnDLUSAUSvswpzs9jvJpeZeMyOyvySVln0tUdlOX0Im8+VFWMz6ezshrPsq+XP29VwF/3fJWVZbwqx2fFPK9ux+s1ptvCVVGll+P1jf9Ip9WtvRBW93dZ5HGX6v4FZ5/TPM8um/fzKjk9Nc9fnDxfvYiNV1hW6axeNi2LvEk2zZPIJq259Z5NJgHCn0H8wXcAx0COGdlSlOWT1hJ2TPiNL0fco5qXi62akpPk4/aUuHCTcPr65YfEt+y88cHe51/y4kc+eptdFd+zVX76PZvFgvs/2HrVeRnztrz6mPH7absTjh69ZyhVEnVEJN4FL72jHoJ2FlqdkD6dMEoEk2K3Ez5oJ1J0Y3Kd/xhKuOisBMldSl6/SU4GwOT6wf6DEkKNA86AmkCJ9QaDVZYhNz6xhnDWqoT2qSR2E0bheo3tSsSglYiOSsTjKaERSmcloA6jl4g9IKGaMS7QEC0VF9paL60VRLpEG4x8WpGwHpFISgG0xt1I/o9c+2HC6mZCdBcm7H7NZBhM9jJyidgwgkZihWdKgeRITfwvzr1PgtQ0tDrhfTqJZyIGIHCnk2E3k0MZuRoljHVWAjen8YEq2cfE5a1FnjhNhCKWhgSMiQAgCDCJiqeVViSiZyQcQegDRnIoE1eDhENHJHTjKDPwc8k+Rq7IISQmQglBGnAJT4wNSgfKPfHO3+yqayWyPyWxi4BWhOrdIxcftBIE3o3JuuCBnajaCXY6majGiTwQJ+sn+w9QuGGOCYMBnfOScBMci10lnlQEEA++FYrqFQoCSISDnrlUNyfX+Y/BhIjOTNZj2sBnLrUHJExLmShutfPxYBJ/xcmLOM4tc6DszelzjUT3jIRIvKObqEEjOZSZq0FCOx1MFkjuPJgMpJfsZebyghrOnFE0fjWdCo5SgoE7B+CFcm1KBPSoJK4hKAq5WwkdtBIE2o3JuuBhnSBpZi7s4KQuiTPXgzeTPwAAAP//nFbJDoIwEL37FYYDN+iG1JoQv8Q0pZYlhCVtMYbEf7cUlXDSeJ195s2bzL8vF/mRJ/vLbBh06m75MEce9YJCZe1gTgBMpBN5VGB4pCxisIAJmm+6hOmVsEQeBFYK5pRhJOLJZVOmiVzLZd2VsexbIIYa3DBYGzXnFRguR216nSGapO6VYgSFG76+9d8oG/rSTT2pDMHwtUzZdpGCShje9tpDa/WovPDjuIxt93gCAAD//wMAbDbnfbEgAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:39 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "9abfa749a603fcf370a003b3ed061ed8"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746043338&engagement_id_cursor=6CDA0A11A626D34DC704C379DED404A8&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:39",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746100931&engagement_id_cursor=FD63A54CA83010C8FC3321F5CC00D68C&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+zXW2/bNhQA4Pf+CsMPeWqaw+shAwQDdWExYEuHpdsehsFQbcYxEkuZJKdbiv73UXJs5yYnQuxEBmYYiGOeQ0qkPvPw27ter5+MXVoOXDr2H6bVx1FSJv3eYe/P3jff7iNutU1GVUvfqshyG1JqgQj/MgwI0ZFk1NgoNth/P88sJ8Nzt8jSHCS5aZgPOv8epaSEKS2ZYnjTPs6z2eXtdqI0aAb6pj13f89cUbr8JkZJwYkEfwGMLPrITk99ezmZukHhhlk6KqpIsbiCopiM0/qmymxwOsmLcpC7y4t/H2TAnWueuqLwn4rBMJul5cP2qo/JY81lViYXg9WFf00m5YOxcHF5F1nqBymfHT88S9LUXdSr83N8cmI+/nj8cbEMtxawKJO86jUpsrQONvU8uFFjbDVkHUmBin3wb/KZ0EOgh1Q+kuTSUWMKO+Tk3qPhxyhnxXyoOuU4/uPxEN9xHXDy6aff46hh5Fs39lt6nmZf096vbppduUV8cuVyn/Dsea06nRU+7JF19xHf3zcjieJAhLERgtkAUCvK/D+h5aEmRoZhMxK6TSRIEZmkei0S2WkksiUS+ZZIGG2NhN1/NDqKRG4ACYkjGmomIIAAMYyZZUHkXxJDxoGZRiRsi0h8F1pzhet3Et5pJARoOyWrhFdmIismpBUTWTERfDeYrCb2BU5MBBEQJYz3AiZEEto4Am1DCEIS87DRCd+mEx8H8FTF1e3NZFcqrloJxdZKOH1Kyadf4uMOMNlEySWEoloABiqMDPqdxQiiPRweI7GUBY1KxLaV+LfYYSVStlOyjH8LJe1KrloJU7uxlyzn9QVIJLeBP4ggYTZSgRWhiGJqGOEYQWwkNCKRW0QiiRBAQLC1SFinkRBoqWSV8LpMKLQuuaoUX3I9yaQjm8lqZl8CRQLXEbFGM0INIpWAwlgSEUAerqm5cItQBCrOie9qLRTsNBRs6QTfkglVrZnwHTmZ4AaQiDgIJBrGlY1DABrpyNc6jAjKwVdgpBGJ2jYSKZRei+T/kmtjSBhvj+R+odFRJJsouUIMI6atABkGFFByxfxfZiUTsQbbfC7RW0SCUisAget3Et5pJFq3Q7KMf00k9DPUSOD5SOYpHgnbkYJrObEvUOIfxyDgSjPLiImE8b/hSKQxnBGtKTVNShC2rMSfSwSuVSI6rQR5OyXL+LdQQrC1Ena/yujoVrKc16eQ9P6qAvup+6ccXFYdz/L5IpyV5WVxeHBwzdLky/4pBYV6X8MpcCI4wBDkiGk+FAl1Dr6gpiT5cO1Hc8X5vr/j8SQdfxhm04PkcnJwRQ9W91n8sFqXwXCWF1l+RJBL4g8bDPfuYF20P+V1r770YnLtjgjs3TxLR3efo/5ZUgymWV6vbJnPXP3lMnF+lnv3/T8AAAD//wMAYiO7LqogAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:39 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "13"
+          ],
+          "x-request-id": [
+            "5ad78511740b0a94c2c9d25212d11544"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746100931&engagement_id_cursor=FD63A54CA83010C8FC3321F5CC00D68C&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:40",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746144137&engagement_id_cursor=980BB4893F31AD5A844716AA4319922A&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXzW7bRhAA4HufQvA5AWZn9m90I7ncIEBrB3WSHnIQCIt2hdhkKlIJiqDv3qVsUWpsKiZUWhSkA6Gd2aWG/LCz33+ZTM6ym7yoZ3lxEy7umst5Vmdnk+nk0+R7GA8RO2OLeTNyRs7IiLQhjL0jMqQTg0wulT7WkvXZq/vMenH1Od9ksQQjHgbuF73/3WiNgixrsmQexm+W5erL7riwDEzAD+PL/K9VXtX58iHGaiWtYLYKzWaO8vo6jNeLu3xW5VdlMa+aSLW5g6pa3BTrP1WXs+vFsqpny/zL7d+PMuA/93yXV1W4qmZX5aqoH483cyyeGq7LOrudbW/8W7aoH62lN7d3WxZhkfrZ8Vd/ZkWR366fzm/p5WX05u35m81j2HmAVZ0tm1mzqizWwdG6Dvm8M7ZZch2JgOo1hC++B5gCThGfSMqLeWcKTdH88GqENepVdb/UOuXiXXr+dEyYeR1xefHrx9R1LL3zzz4Un4vyWzH5Pb8rv+ab+OxrvgwJzy5sM+mqCmFPPPgQ8c+rbiVeqhiEQpJOc4paJeTBAzsriCPATiU4nBIFCgUDEZ2wEgGmH5Ntwgs7kc1LD6KPk5Aip9L+zMl5+scImGwLe4ATlyqrXeQSdjKJIZUcByECKIoSJbXvdEJDOmFDYIXav5uYUTsxth+TNv4YSoTprYTUaShp63oAEi1RJuBCzwWcsnNGMVrLQipjyKmkE4kcsOVi0tYiSLUXiR01Eq17tlz6iEhQ9kcCp4GkresBSAQLNCxJCPRJ2FSsTzlsJzaSDoURrhOJGg5JOJGEjgsF7kciR41EkOynZJvwwkxsczKhXh2XXXdcJ7KXbAt7gJNYx5JQphqNViJ8ZHiFHdpYWxMRdW8mekAnJFCTUmJ/xyVg1FBY9XPSxh+DidK9mWxldTG5eJeej8BJW9gDmACZiEEIxToCH9od9hR2lCRiH8dSYScTMyQTCFuJ1IpOmYmBfkza+JdnQlPoz0ToE2HSFvYAJmw8JEni08g6YRMATXGMNrFpQoZS38nEDshESSOlNSBOuesSPZlsE17WicBmO0Ho4aRJCU5O5HCyLewBTkhbwlh5iph8jC5CQuGDnXA+sWrPdsIDO1FSWd7rxIzaSVug5+4mfEQlZHoqoZ0+bdxK2roegCQySWwgBfQq1bFgSIQ0oQFLndJkrOtCYmFgJFqy2n80saNGok0/JG38MZBI2R/JT08m/zuSfwEAAP//nFfJCoMwEL33K4oHb5pJjEsK0i8pEtO4UFxIYimB/ntdWsWT0OvsM++9w/wlkvWuRyI536ZAp5Uvk/VT4UEtIFTG9PqCkA1annsFgSRmHoMCKA4pgIDoHjAqQk6khDxmBHPfjt2kfnjjxmXdlr7oGsT7Gj0J2vbU1w2XTAxKdyrFI/NxEgcRdXdi/fmP9OrOo+vayhSD++VSuueRU3GdNZ2akTVqkLNxTVz+mdP7AwAA//8DAIgo5ymvIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:40 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "59ca5b91bf848721d13565b5ddbb03ed"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746144137&engagement_id_cursor=980BB4893F31AD5A844716AA4319922A&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:40",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746187364&engagement_id_cursor=A7CB70E02F5E6B190C147596ED56378D&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SXWW/bRhDH3/MpBD34KY5n9l4BRsFjNyjQOkWdtg9FITDSWhZskS5JOa2DfPcudZC+aJtQZUsAHyjOf/aY2Z9m9tu7Xq+fTFxaDl068S+z6nWclEm/N+j92fvm7V5xyzYdV5Y+RFFgQ8IhFkwAl6EiiseMhgSB8ID03y89y+nowq29NAOFK8Ny0uV3KQRBqrSgisqVfZJn86vbdlQaNAW9sufu77krSpevNEpwLrhfivYDrTTZ2Zm3l9OZGxZulKXjolLS9QqKYjpJF5sqs+HZNC/KYe6uLv994AF31jxzReHfiuEom6flQ3s1xvQxc5mVyeWwWfjXZFo+mAvJen2XWepnKV/uMDpP0tRdLvLzszk9DT7+ePJxnYhbKSzKJK+GTYosXYiDRSTcuFVbzblQEp/cQ/AP+YxiAGTA+CNOLh23urABU/cOh5+jnBfLqRYuJ+aPxyV+4IXg9NNPv5u4ZeZbG/stvUizr2nvVzfLrt1an1y73Du8PLDVqPPC6x5JvVd8f9/OidWxjaSxXGpqjNUSmRXahCTkFP3PVk7IFjmRmlEtpJZPcoKw06Ao1o2TWv/6mNAB6M6YULofmNRx3YCSKLIK0EoKligm0dJIcYwiijwkVkArJXS7lDD0YtxnSoTsRkmtfwtKsDslROwHJXVcN6CESeDK1xJNuLHAOQsMEmUpmpgwK9trCdsiJZoDKImCP0kJ32lIEHg3ShqH18WEQNVzoeyASeXCvNd+YNIEdgNOjJWaMMFBI40MBhAGWocYMVTG+OPcygnfJicSQEjG6ZOcyJ3mRHYsJvJtismSkqZ/eiEldMDvH40dpUT+D8XEKBJFTNgImIx1GAeCWqP8vYQa8M3X/TtaA4nYajERUhGu9B5DIkQ3SGr9m0DSpeNaQsL4fkBSx3UDSELpm6soCtBqHTGuQVhleCAiFTAMMGyFRG4PEoGUasXlM5CwnYYEAbtR0ji8Jib0MywwgZd3XEsXj8n9f9AdxaQJ7CacRMgRQVnGQxOjDGkY2MAi5ZpZGt6/ozWcqG1yooEJ3wfik5zs9s1Esm6Y1Pq3oIRgZ0ronhSTOq4bQAKS8IiDCQLg0sTCspDoULBYRDpUsWmFRG8REkJ9u8W12mdIBO8GSa1/E0hEd0jwOUg+/WJOdoCSOrAbUBJQfxsJhQ1jDCSPAmalDdHGJmAKQQdtlGjYIiVUcwpSML7HlCB0rCWNwytzwgbVA1048Xo+YGw/ikkT2Oc46f1VCfup+6ccXlUjz/NlFs7L8qoYHB3d0DT5cnhG/I1DH2o4A4acAYxAjKlmI54Q5+CL1ASTDzd+NldcHPotT6bp5MMomx0lV9Oja3LUbLT4oUnMcDTPiyw/Rln1URwYHNzhdW1/DtmDxdKL6Y07RjhYHabjuwepf54Uw1mWL1Jb5nO3+Fg7LsP27vt/AAAA//8DADLXdBawIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:41 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "11"
+          ],
+          "x-request-id": [
+            "d6359460253841d6a21603a9789908a2"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746187364&engagement_id_cursor=A7CB70E02F5E6B190C147596ED56378D&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:41",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746245040&engagement_id_cursor=A3D9BB6FBD1A75CA4F7FB1FDEA48109A&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXX2/bNhAA8Pd9CiPPHcDjkUfSb5RIFQO2dFi67WEPhhArmdFE6iy5xVDsu4+S/2VO5JVwFcuAHwTfnShR+unIL99NJlf5fVE2s6K8DweP7eE8b/KryXTyx+RLiIeMJ7HFvI1cSW4VaG0ZU6lLtbeSZZ7IZl4JjWSv3qwrm8Xth2JbZQQzsAmsB13/r4g4oDaEGtUmfr+sVh+fxkEbZpCZTXxZ/LUq6qZYbnI0SUJSnDHgcpNT3d2FeLN4LGZ1cVuV87rNpO0V1PXivuxuqqlmd4tl3cyWxceHv59VsP9c82NR1+Gont1Wq7J5Hm/PsXgp3FRN/jDbX/jnfNE8G0ttL++hKsMgzVfn3/6Zl2Xx0D2dn/zNjX37w/Xb7WN48gDrJl+2Z83rquySbTcPxbw3tx2yy+SMy+9Z+OF7JqbhB/KFoqKc95bIKcLBqxHGaFb1eqiu5Nr//nJKOHGXcPPux9+86xn5yY39Wn4oq8/l5JfisfpUbPPzT8UyFHz1vLYnXdUh7YXnHjL+edOPxEFqjJCWmELHEDl55oR1LEm0lM71IuEDIhFgDFOGLhkJRSKhcyLhLBoJp8tAQt8AiZRMauadQ3REHrhQIKx1DtAZUKoXCQ6IhECQZFqpo0hw1EiMiUOyy39lJHrK+BSjkOjWFTOXgWQ3rycgySQnZh2Bc54J5lLJXUIJR5e5NEv6O4kYEgkLqy2NcByJHDUSJeKQ7PLPgURgJBKcysPv5zMk73721yNQspvYE5Ror3QgkSSZt5lLfGK8MC711mEiwfheJXJgJcBBXrISilRCZ1Wi45XwC1FC30AJOhBcWJEmlltwxjpthMgIUwTI/GFX3SuhAZVowThqQXBUiRi1EmAYx2Rf8LpOgLdOWIyTtiQ4gQtxsp/ZE6AwnQiV6rAVyNC0XhKLgY7hZITL1OEebQ9FDQgljC400P9AoVFDURTnZJd/DiY8ZtG1ZoIXsjPZzesp3cRKoyQk1qapIESlFE8UyPCmmiyF/p2JHrKbSA4EXB1fc40bCck4JLv8syAx8UjEZSDZzespSIRRYFMmgDIy1trMWLQGOPpMcXU4E3skZjgkKmx7kAuu5VEkOGokwCBOyb7glZlQt+SSMUyoZSIOlxkjZbKf2BOchK+2AvLGOGnIicwKZAjOUwCD0sgeJ8DYcE5CHwtLLiKJR53IUTtRkc1EnamZdEogqpnQOZvJvwAAAP//lFZJDoIwFN17CsOCHfS3jDVpPIkhpZYhBGjaYgyJd5dBJazU7Z9f3p/+/rh+PSbHy2zodPJuMzUHHvRKQmWtMieExqDjuVcQSBPqUSim2xKFAALia0BDEXEiJeQJJZj745RNmsabEJd1V/qibxFXNboRtOE0542XTAza9JrhJIxJmuKAurthfeu/zau7lG7qUTIM7quX2L6PnIqbrO31wqzVg1yEH8d1txweTwAAAP//AwAtVra1qiAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:41 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "da736cfd1af8b97459bc45bc8a97e057"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746245040&engagement_id_cursor=A3D9BB6FBD1A75CA4F7FB1FDEA48109A&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:42",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746288139&engagement_id_cursor=216716E99D596D4FA43031DE6AF93595&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SXXW/bNhSG7/srDF/kqmkOycMvA8FASVQxYEuHpe0uhsFQbcYxEkuZJKddiv73UXIc5UtJhMSNBfhC1nkPD0Xy0Xn1/c1gMExmLi3HLp35i0V1OU3KZDgYDf4efPdxr7gWm0+ryBANMVFsIdYMSRzGWkU80CTGgEUxQTt8u8os55MTt87SSIBcBlZFV/elEJQwpQVTTF7GZ3m2PLseJ0qDZqAv47n7d+mK0uWXGiW4BJRcAdC1Jjs68vFyvnDjwk2ydFpUSr6eQVHMZ2n9UGU2PprnRTnO3dnpf3cy4MacF64o/FUxnmTLtLwbr8aY3xcuszI5HTcT/5rMyzu1xHp6p1nqi5RP1k+OkzR1p/Xu/G4PD837Xw/er7fh2gYWZZJXoyZFltZiU6+Dm7Zqq5K1kgLlu+B/7CMRI6Ajyu9Jcum0NYWNGNw6Gr5GuSxWpeqUA/vX/RI/cC04/PDbZxu1VL72YJ/SkzT7mg7+dIvs3K31ybnLfcKT17UadFl42T377hU/3rZDEltmpTCUceBoAxkLEkRcIwOKCmQ7JHSDkFDKhZDI2YOQ0K2GpFmhJ1LSJPxcTChUmBDsgEmVwkZc9AOTZmGfwYmiOtASdGAQiLU2tDYIDbOBP+xM2dtvjIYTtklOtAZkEvrcTGTHZiJfp5msKKGqMyXI+kGJfIFmEnESS0U8ERKtd1uGWkkjygzh2lKrWiHBTUKiqFSUsYebidhqSHriuFaQsO6thOl+QPISjstagzHnPLYiIjRSqCKiYqOUpcI7n7AVEr5BSDho5f2WfBgSttWQNL32yY6LvQIm+BG69pJVCo4IeQyTD3/Ygy3gpFnZZ4BCIxFzKcDQmBgZAQslSm/CSIgUIi1bQREbBAUlEIa635ZLdOPkSv8amCDtiIn/MLltNLYVk6uFfQYlkgUmAstMpJhVnMaxrRqKUTE1AAZbKZEbpIQDchScyx5T0gvPdUVJ12biKenJh8lLeC4lQx4ihJZxoTGgEAcqjDUVyoTMaNMKidogJEJo4qejHm4l2+65sBslTcJPxgQrTIB3wQQrTLAnnybNwj6DE0MViph4myVDG4aAsT/mcSgBELTnp5UTvUlOpJIavO16kBOx1Zz0xXLVlFDoTAkT/aDkJRyX5hgqZSNNUMtQSMmlRyCi3IL/F95uq1eQENggJJIoQCSPOK7thkR0hES8KiSiOyS0H5CIp0Iy+KcSDlP3rRyfVQMv89UmHJflWTHa27tgafJl94iCf4PvajgCf0IRYAJiyjROeEKdgy9SU5K8u/DVXHGy6594Nk9n7ybZYi85m++d073mOYtfmn0ZT5Z5keX7RKJgjDAUOzdgXccf43Wnnnoxv3D7BHYuz9L+zXM0PE6K8SLL650t86Wrb14lrhrwmx//AwAA//8DAMxf8CisIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:42 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "15"
+          ],
+          "x-request-id": [
+            "c14c86233f45c0afc44ae9310151b31b"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746288139&engagement_id_cursor=216716E99D596D4FA43031DE6AF93595&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:42",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746331346&engagement_id_cursor=954C88ED91497C67757941D25E0C67C3&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SX30/jRhDH3++viPLA03HM7O+NhCrvrn2q1HJV6Y+Hqop8iQnREZvaDtdyuv+9axNiCDhgQcBIebAy39lZz+7HM/Pt3WAwjGdJWo6TdOYfFtXjNC7j4WA0+Gvwzdu94oZtPq0sQxE5gRhRJIzRkFgqBEBgrHVaKxVGw/dXnuV88iW59tIMEVeGq6BX/0shCFKlBVVUruyzPFue37Sj0qAp6JU9T/5ZJkWZ5CuNElwBKsmZUHylyU5OvL2cL5JxkUyydFpUSna9g6KYz9L6pcpsfDLPi3KcJ+dn/93xgFt7XiRF4Z+K8SRbpuVde7XG/D5zmZXx2bjZ+Nd4Xt6JhSBW8rMs9VHKxztMTuM0Tc7q8/k5PD4OPv549PH6IG4cYVHGebVsXGRpLQ7qTCTTVm0Vs1YSIHwf/I/9BmoEZIT0Hqcknba60BHXG5fDxyiXxVWo2uUo/PN+iV+4Fhx/+umP0LVEvvFiv6df0uxrOvg1WWQXybU+vkhy7/D4xFarLguvu+foveL7+3ZOHNqARsg1BwpoLCHgMAhBstA6abCVE7JLTjhBLoHTrZyIXnMidTdM1vrXoITIzpQw8TYoWef1CZAEkWFOShcaBSQCx/ztROsAgyAwhJBWSOguIQFChSREb4VE9RoS0bGWiNcsJZR3h2Tz+3kHkk+/hEc9oEQ8QymRGBrOlCAkNKHjPMRQaw+JokCCCFgrJWyHlKDwrGqA7S0X7TUlCLQbJo3Dy3KCpOKk6Z8ewUnlwkZs8xPaV06azD6lnFQFBEAZKbhzzHdZGAhFjTWOIgXVCgrfJShMEgVU4VZQet5z8W6crPUvjwkdIeuMCXkjk8k6r0+AxCCNDBJjUQuu0YnI91xOhAylNqwZ6+5AInYJiUABBOVbHkxER0jEa0JCoDsk/I3UEvEMlFBlJYKgobYQKV8+AK02GgIDTkdGtlIid0gJYxxRK7F9MmG9pgSRdOy51g4vzImoei7sMptULmwEm5ejp8WkSewTOLFScTTcsoCCQRtZEVlKjHPKOCHNZvvZcKJ2yQmVgmlO33I1UR0xUa9JCSUdKaEjvjm29rWaqGegJGA8FAYdB+Q2CgiaMOTEf89V5ImhopUSvUtKONWUKrJ9MFG9pkSobpSs9a9BCevUc9WUsM2Ztae1ZJ3XJ0ACQEBKGgC1PCI2cBZNoLl2TLJIoW2DhMAOIfEjElAhHmi5aK8hQcRulDQOL4sJgQoTLjpgUrmwEXuw5epJMWky+xAog78r4TBN/i3H59XKy/zqGE7L8rwYHRxc0jT+vH9CQEm9r+EEGHIGMAExpZpNeEySBD5LTTD+cOmjJcWXff/Ks3k6+zDJFgfx+fzgghw0L1r80JzMeLLMiyw/RMk8QUpLsXcL2Gv7Q8zu1Vsv5pfJIcLe6jYd3r5Jw9O4GC+yvD7bMl8m9Z9rxzpt8O77/wAAAP//AwBRWmaFsiAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:42 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "11"
+          ],
+          "x-request-id": [
+            "76a0e77606aac11ba367456deaf93a7e"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746331346&engagement_id_cursor=954C88ED91497C67757941D25E0C67C3&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:43",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746388976&engagement_id_cursor=0020773A03C5F2CADC1BA959D474F81C&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+zXX2/bNhAA8Pd9CiPPHcDjkcej30iRKgZs6bB020MfDCNWMqOJ1FlKi6HYdx9tx3+WRHYEx7EKFPCD4LsjJUo/8Pj1h8HgbHxdlM2oKK/Txe38cjJuxmeD4eDD4GuKp4yt2HQyj5wZkmyQgxdBK0NWChBWSR05IuUmnr1ZVjbTy4/FqsoqkHAfWE66/N8QSUC2hIzmPn49q+4+bceBrbAo7H18Vvx9V9RNMbvPYdJMSkHKXY9RXV2leDO9LUZ1cVmVk3ox2uoO6np6XS4eqqlGV9NZ3Yxmxaebfx5ViP/d821R1+mqHl1Wd2XzOD4fY/pUuKma8c1oc+NfxtPm8d2tHvCmKtMkzbPzL/8al2Vxs3g7v8SLC/f2p/O3q9ew9QLrZjybjzquq3KR7BbrUExac+dTLjKlkPpHkX7qvRRDgUNQTxQV5aS1RA0RH3waaY7mrl5OtSg5j38+nZIGXiRcvPv5jxhaZt56sN/Lj2X1pRz8VtxWn4tV/vhzMUsFz17X+aB3dUp74r2njH/ftCMJWjhy1hoZc2ONwCzazMfMOhNl+pZbkcgjI2FpGHYi4V4jIeqGZJ1/CiRSdkYieR+Sd7/G8x4oWS/sAUqsNp7ZapsLFTz4YBRpyxK9lg4IWpXgEZWwRbKo9mwl1GslANCNyabgNZ3o9yJ99HKI8GwnyxK1Ravfm8lmYQ9wwpyDjzkEmxvv0aDm3LBkIIe5dbbViTqik5RgpCXavZv0u+Vi0Y3JOv8USpTtrEQ8/DT6upusF/YAJdJF4SCPzkqTZV5BxiKiCJHyADq0K9HH3E0UC1RK2p1KvvdcL6ZEm+5K9h5MeqLkZXouzYIcJRSZimkvkc5wTg6iNzJAuxI6nhILoDRpgN09l+q1EoCOTDYFr+xELZyoLk7U3Il+eGztbc/1Ak5IZgKMtzrKnCNJnencO5ELx05HfNh+bpyYYzpRmPAi4k4n/d5NWHbsueTJlOAQsLMS1N+GkvW6HtJyUUjtlSKdvmtgE4IXPtOChPaU29y3IuEjIhFphwNlxTfdctluSNb5p0AioTuSvVtJX1oue7gS8pSRxEBGYWq2JGTBaW1crvPMeQOtSuwRlaBJRxM0e5Rgr5WA4G5MNgWv7ITnToTs4oSf13L1xMlmZQ+AwiZTXqN2LkMKqJSQgqxRDIG0D9QGBcURoSiRTiaMdvfZxPQaijHdnKzzT8FEis5M0Lx6z/UfAAAA//+cVEsKgzAQ3fcUxYU7zSRGbQrSkxSJafwgRkliKULvXj+t4krodv5v3rz5SyXrXo9Ecr5PgY6SL5t2U+FeLySU1nbmitAQKJ55OYFLzDwGOVAcUgAB0SNgVIScSAlZzAjm/jB2k6b2RsRFpQpftA3iXYWeBG04zW3jJRW9Nq1OcEwjGhAC4O7E+vMf6dWdRzfVIBMM7veWkv0dOSU3adPqmVmrezkb18Tlt5zeHwAAAP//AwBId4aFryAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:43 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "8"
+          ],
+          "x-request-id": [
+            "4e4643d0a1102e08e42c5a6c473319de"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746388976&engagement_id_cursor=0020773A03C5F2CADC1BA959D474F81C&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:43",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746432200&engagement_id_cursor=87C4B535AAC36D344020697481D65BD6&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXzW/bNhQA8Pv+CiPnDiD5yEfSN36IxYAtHZZ9HHowhFjJjCZSZ8kthmL/+yg7ltPEqks4imXAB8F8j5Qo/fSevvwwmVzkt0XZzIryNh7ct4fzvMkvJtPJ+8mXOB4jHo0t5u3IhfEOrRJBUaWYzdAxaoWyYKSW3NNw8WaT2SyuPxTbLM0p0IeBzaKb/yUio6A0ggL5MH67rFYfH49TpYkGoh/Gl8U/q6JuiuVDjEKhOUEBnPLtGtXNTRxvFvfFrC6uq3Jet5G4PYO6XtyW64tqqtnNYlk3s2Xx8e7fZxnkq3O+L+o6HtWz62pVNs/H2zkW+4abqsnvZrsT/5wvmudntz29u6qMizTfHX/9d16Wxd367vySXV2Ztz9dvt3ehkc3sG7yZTtrXlfl5lau96GY98a2S64jGWHiR9L+fidqSmDKcE9SUc57U/gU2JNHI67RrOrNUuuUd79ml/tj4szriKt3P/+Z+Z6lH13ZH+WHsvpcTn4r7qtPxTY+/1QsY8J3b2w76aqOYXtufIz4702/kuCEZvGh1GAhaOYZSiaMVsxkygsme5WwAZUgFwhiN8d+JWLUSigRaUx2Ca/rhLIpiT+V4KRNgamAM3Gy29ljoBCbuagkWEckECQuoHAQjTAiuNC9UGBAKEJLEa1213eO5USqNCdd/CmYMJbMhJMzYdJt7BFKMsN0cAgymPj+zrxXhnEvjMRgPff9SvjA5UQodqCcjFsJyjQlXfxJlKQXExCHlFxmf40ASbevRyDRykcMHCzToDJAIhgw4inlIF1QqheJGBCJAg5ADiGBUSOhhKcp2SW8MhNsmdCUb5M2hU/JwWIyDia7jT2q5fIKrTXUExNMcI54NJxifEydNYH2OsEhnaACoOS8Wy5MY9LFn0IJJLVcuG65nr5CR9ty4QsoYaCt17HvikzAKo4ii18nwgijqaL9SuSQSmI1QRZjz1gJJirBkypJark2SviZKMEXUGKkNkSjDSRTmeGMO6QOqKEmgOb66VbslKjBlGAsIkRKGaf6phIxaiWUssSeq0t4XSeMtE5EipM2hU/FwZ5rJE52O3vMxwkNFr3PqNM+NlzOay09RdRIg3He9ELRQ0JBFusax2+XEzVqKIqkOeniX58JpH2abJgAHmIyjk+Tbl+P6bkoDcJYGriUylrLfYaWBa4d0U6wrA8JJ0MiidVEC0HlGSNBmYakiz8FEgbpSA7WkpdG8j8AAAD//5xWyQrCMBC9+xXSQ25tJmlrrFD8EilpTBekC1lECv67aVxKT4rX2R9vHjN/vlzsR5FsT3Ng0MubKca5sFVPEhpjRn3AeIp7XoYVhT3LwgwqSEiaAAjYnd3jJVJOpYSSZZTwaHLdpL6EDnHd9nUkhg7zscVXihec+rjwUgir9KBywtx1YK5ujFZiffu/6RX50XU7yZwAeu1Svt6joOG66AblmTXKSm/8JPoDDJv7AwAA//8DABLQJPmwIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:43 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "7b9092a00a50fd3208b70f400c59853c"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746432200&engagement_id_cursor=87C4B535AAC36D344020697481D65BD6&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:44",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746475403&engagement_id_cursor=F11F5AB1F4778BBB4DE6B2F49C09C52E&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXS2/jNhAA4Ht/hZHzFuBwHiR9E0VpUaDNFk0fhx4MI1ZSYxNpa8m7KBb976UcP9JN5KzgtSMDBixkZkSZ4pchP383Gl1Mb4uymRTlbby4by9n02Z6MRqP/hx9jvGY8Sg2n7WRCzFes0UjLvOSIussCWhBM/hMcuKLNw+Vzfz6fbGpcgQE68DDoA9/NyIa0DrBeMd1/HZRLT88joN1yqFy6/ii+HtZ1E2xWOdYEaW1VoaV4nVOdXMT4838vpjUxXVVzuo2kzZPUNfz23L1o5pqcjNf1M1kUXy4++dJhfrfM98XdR2v6sl1tSybp/H2HvPnwk3VTO8muwf/NJ03T8YCtZmBu6qMozRfX3D917Qsi7vV+/kpu7pK3v5w+XbzIh69wrqZLtrbTuuqXCUnq5koZp257ZirTK00f6/iR35Veqx5rMwzRUU56yyRMdMXiyOO0Szrh6FWJZfZH8+nxBuvEq7e/fh7FjpGfvTDfivfl9WncvRLcV99LDb504/FIhZ8/cS2d13WMe+ZVx8z/n3T7YR8cBach5wCBsoxyxU6xd7nBJh0O9FHdIKk2BqnYK8TGbQTY/sx2ea/hhKNvZUQnIeS7bwegAQdJ8BOxCSgITjx0V5uOE0AIaS2EwkeE4lisWLsfiRm0EhE+iHZ5r8GEoTeSNC8hOTdz9nlAJRsJ/YAJaxVYjIKFNel9XmgLI27HXAK0UvsLJ1K6IhKSIsB1rJfydC3XNCPya7gxE5oHNe94j5OYgmOSc6jmewm9pAtlyhn0tTl7NJ4IgleS0BqL+IGTNIv/2XsnPARnSAKCbDsP5rwoJ2Ynt3EvFI3WSkB21sJvngwGUg3Md+gmyjKPcejCCJqMMLtEk88imGVagfd3USOqISI0Glz1geTc9lzrZRo6q9EnUcv+RZbLmUcOcoCxmVPNndaJ2StCorEx46SdyIxR0QiIM4AIO5FMvAtl+6pZFdwYia2ZYLSh0ksoTHp82Cym9hDtlwmgxAC5mCNRW+FPGaJc6nzHCz4Tif2mE5iezMaye11AmrQUBz3c7LNPz0THCvozQTP5GSyndcDlDiVWvacxgVsEJOgRRAy5sQFDCy2U4k7ppK2xYFRLyiBQSsR10/JNv81lIDurUTDeSjZzusBSnIFOqVUp8pYk2Yego5f7FNDeU4udClhdUQllsVYYOG9SnjQSEBRPyW7gtMyAd3uuXoxaUtwzCdvJv8BAAD//5xWyQqDMBC99yuKh9w0Y+LSFEK/pEhM44K4kMRShP57XVrFk9Dr7G/ePJg/f651sUc6Od+nQKdRL5t0U+VeLywU1nbmivFAG5G6GYFLzFwGGYxCCAAkRA/KAhkKohSkMSO+8IaxmzKVO0LOyyb3ZFtj0ZX4SfAG1Nw2YhLZa9Nq7sdBFFLCKEE7vf78R5JF8+imHBT3AX2Pie8PySmESepWz9Ra3avZuCYuazu9PwAAAP//AwBwg1nYsSAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:44 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "386e6986b3ad28d1beed2f3e9d32514a"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746475403&engagement_id_cursor=F11F5AB1F4778BBB4DE6B2F49C09C52E&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:45",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746532932&engagement_id_cursor=F012C4C2C0787CEB1D27CE5BC74FF49D&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXW2/bNhQA4Pf+CsMPeWqaw/uhgWAQJaoYsKXD0m0Pw2CoNuMYiaVMktMtRf/76Jucm5wInmMZCALDPIekSH4+1Ld3nU43Gbm07Lt05D9MZh+HSZl0O73On51vvt1H3GsbD2ctXcplrKkKNNOWGUGYUhYwQo0gDESy+36RWY4HV26VpTkRZNmwGHTxvZKSEoZaMmRq2T7Ks+nN/XaCGjQDvWzP3d9TV5QuX8aglIBCIgBqtozJLi58ezmeuH7hBlk6LGaRcjWDohiP0vlDlVn/YpwXZT93N9f/PsmAB3OeuKLwn4r+IJum5dP2WR/j55rLrEyu++uJf03G5ZOx1Gp611nqBylfHT+4TNLUXc9352d7fh58/PHs42ob7m1gUSb5rNekyNJ5cDBfBzesjZ0Nudh0oOIY/J/8TGgPaI+qZ5JcOqxNYT3OHh0NP0Y5LRZDzVPO7B/Ph/iO5wHnn3763UY1I997sN/SqzT7mnZ+dZPs1q3ik1uX+4RXr+us02nhw57Zdx/x/X09EqWNiQQVDGmkAVHwKDaKezYYGQyDWiR0l0iUFlQrKjYiUa1GIkUzJFX8PpAw1hgJw8NAUq3rFkgsBpxYJTRDIDKOoyhUBAIA5k87ieNaJGx3SAjRSvhQ2IyEtxoJoaqZknXCGzORzZn4FN7jcBhM1gu7hROBNoyRUhPGHokMJTIrKEdlg1hIw2ud8F06YUJxPymy0QmBVkPBhk5wn0wENmZCxUtMPv1iz1rgBP8HJtwYqWlgwtCEVhuhfFkJI4wZZaFWENUyEbtkIkBIpqqYGiak1UwkNrx04d6YsB7oxkyIOoxqUq3rFkriKGQm5hjqmOrAysAwSSgRQRRyHsjHdXWtRO5QCVdMA1N8czGhrUZCgDRTsk54WyYUZtUEeAMmsxTW44dSTdYru83bCVgtMNBWImpLVWgiq0Ppr12Syiiqh6J2CIVJ8FcuITe/nchWQ1GsmZMqfh9MSJNqsmDC6GFUk2pdt0BitOWc+V9vFQvGuASILQkNJYE/7DHXtUhwh0i4kASpoIeMpBL+2iuX2CMS2ryW0MdHo6VIqnXd5sVEGhlSChEPBBGxv+0ELAKJJtTcxOLx5XONRO8QieSaUO6LyUYkvNVICFXNlKwT3pKJ+gxzJoy9mskihff442tGa69c1cpuAUVGWgTAEQzE2vr/IjQ8tCawKg4DyeqgSNglFIpEMV718TwUAq2Wgg2h4D6dCGzshL74atKOcoKvVdL5axbYTd0/Zf9m1vE0X2zCZVneFL2TkzuWJl+OLyig0scaLsDXCw4wADlkmg9EQp2DL0pTkny486O54urYP/FonI4+DLLJSXIzPrmlJ+vnLH5Y70t/MM2LLD8likuhJFF49EDrqv0lsEfzqRfjO3dK4Gh5lk4fnqPuZVL0J1k+39kyn7r5l1XiAte77/8BAAD//wMAw5WswbAgAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:45 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "11"
+          ],
+          "x-request-id": [
+            "63782575754f8e0dc3f7b1bb4e56d06c"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746532932&engagement_id_cursor=F012C4C2C0787CEB1D27CE5BC74FF49D&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:45",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746576178&engagement_id_cursor=6D95A0480B0F9E0B05CB4CEBAE7FCA63&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+yXS2/bRhDH7/kUgg4+xfHsc3YFGAW5uwwKtE5R93EoCoGR1rIQi3RJykkd5Lt3KVmWX5RN2IopoBAPBGdmZ18/zX++vun1+unEZ9XQZ5PwMqtfx2mV9nuD3l+9r8EePG7YpuPa0qfEASeINjaJRSOFNMYSpqwWVAIk/bfLyGo6+uRXUZoTSa4My6TL7yglDbFaMsXwyj4p8vn5TTtRGjQDfWUv/D9zX1a+uPJRUobBOecU+conPzkJ9mo688PSj/JsXNae5HoKZTmdZItVVfnwZFqU1bDw52f/3guBW5Oe+bIMb+VwlM+z6r69HmP6kLnKq/RsuJ7553Ra3cslV7M/y7OQpHqy/+g0zTJ/tjien93xcfT+x6P3q3O4cYJllRb1qGmZZwvnaLEPftzoW6dcnjpQsQ/hwd8ABsAGoB8I8tm4MYQPiLpzN0KOal4uUy1CPvzijh72CSMvPI4//PSHsw2pb6zs9+xTln/Oer/6WX7hV/7phS9CwJM3th50Xga3Bw4+eHx724xJEjiRgBq1TihHmxBmIoIJREI75FEjJnSLmCikWvOQZSMmvNOUEJDtMFkHfGdO+ADoQLTihNeccPEYJ0fuzw5gst7YZ3DCJAtAOBs7gpETSgq0kbboWKyUi00jJ2yrnDAAJLCZE9lpTrAlJvh6lLABEa0pYWRHqgm+ACXUSRfHYEIlAZQotcaEx5SqWGkhGDZSwrdKidChoKjNogs7TYkULTWXeEVKKG1NCb17NTpaS6739RmQIALnQWMRTYwEZrm2TmhNCU9iKyVrhERsDxJKBA+MgBIbIem65OLtKFkHfGdMVC252rUmqiZL3L0cHcVkvbHP4IQoTpFTxWJh4og5kwhGEhdLRjiGitLIidwmJyAElwpxIyei05xcT/6pkgtfkRLKWlPCYVckFz6fEkcZ0UK5sAuOorWoeex4JIyhJqKuuTHBbVKiALXkhG2kpOOSq2VjIl+pMVlQwqA1JUzuRi2RL9CXAFhuNSQktCNWKaaiBJiLbGxkRGly9/9iDYnaIiScEKFAys19yf+S60UwIbTGhLTpTOqQILl2BJMXkVxR4hgNN1saisYp1Iky2qJLnNVIiG3kRG+TE44CCRebi0nHJVfLYoKvU0yWlFBsTQl/tDHpiuR6gWpiFJHGRCDCLwYWgxXhQavihIFhURMlCNukhEpARh+RXLLTlOyI5FpSwto0JktKmN6NWvJkydX7u3bsZ/5LNTyvB54Xy0M4rarzcnBwcMmy9OP+CYVQS/Y1nAAnggOMQI6Z5iORUu/hI2pK0neXIZsvP+2HFU+m2eTdKJ8dpOfTgwt6sF5n+cP6XIajeVHmxSFBLiXRTLC9W7Cu7I/xureYejm99IcE9q7u0uHte9Q/TcvhLC8WJ1sVc7/4eB24rMBvvv0HAAD//wMAJeh7wa8gAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:45 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "c169e91388a5921d67d4e2a7a2680abd"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746576178&engagement_id_cursor=6D95A0480B0F9E0B05CB4CEBAE7FCA63&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:46",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746619353&engagement_id_cursor=C816CCA05050B03B0D50D57D8BF30C3A&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SX32/bNhDH3/tXGH7IU9PwePxpIBhEiSoGbOmwtN3DMBiqzThGYimT5LRL0f99lOxYiRMnEVzHNuAHSfc9Hnnkx3f8/qbT6SYjl5Z9l478w6R6HCZl0u30On93vnu7V9yxjYeVpRtKbUWsBWpQlLCIcgBNQUpirNLadt/OPMvx4MLdemkGEuaGWdDZdykEBVR+NIVybh/l2fTqrh2UJhqJnttz9+/UFaXL5xrlNYJzQGw02dmZt5fjiesXbpClw6JS8tsZFMV4lNaLKrP+2Tgvyn7uri7/e+BB7s154orCPxX9QTZNy4f2aozxY+YyK5PLfjPxr8m4fBALiJrLL7PURylf7jA4T9LUXdb787s9PQ3e/3ry/nYj7mxhUSZ5NWxSZGktDupMuOFKbRWzVlJC+SHxP/kRRI/QHoVHnFw6XOnCekQvHQ4fo5wWs1C1y4n963GJH7gWnH747bONVkS+s7BP6UWafU07f7pJdu1u9cm1y73DyxNbjTotvO6RrfeKH29XcxJIaUM0loSEKU+IjCVi4F8sjVjEw5Wc0E1ygigFymc4kTvNidTtMFnot0EJypaUYI+L/aBkkdc1IDGUGRJBDEYjWiKQxDTCOAoj/87DaCUkuGlIlKJPQ6J2GhIh2kGy0G8DEsbbQwLPQfLhD3uyA5QsErtOKQlVFArNYm0EQsy4Qn8+A6qDUBIRLP9fNJSwDVLix+dCAoEnKWE7TQkQ2Q6TxuF1OaGk4oSIFpxULp4T3I9i0iR2DU5EKAUYZWhEfD2BONAQY0gCAG6jWNKVnPANcqIUZxqIeLqaiJ3mRLa8mcjtXExmlFDamhJG9oMS+RPuJQQCfy1ByqKYGa6ViFksBTcxasZiWM5EA4nYLCTcYyj4HkMiWtYSsc1SQlVrSJDvByTiJ1QStCEoGxptdEwNE2FspOWBjSKwKtB6JSRyc5AgCBCaimcqya53XNiOksbhNTFRH8ms49IvxmTm4juu5TZjV28mTWbXAMVSoBAo4o93aAwgF6CYryUxo4azcHXLpTYJCmNeShYw7mM1WZTbl7ZcYouYUNYak71pucT6kEjkWjIbaMSIG+nbLiMCyq1CZa2Mlq9oDSR6k5B4UoFKxCchkTsNyaJffGnLxbcICZLWkOxNy8XXh8Qfd65ZHArkng1prLVhwCLNDCOGB3IVJIpsEBKUytcSILDXLVfLUtI4vDImrMIEaBtMWN1yqf3ApEnsc5x0/qmE3dR9K/tX1cjTfLYL52V5VfSOjm4wTb4cnlGipD7U5Iww4IyQARFD1GzAE+oc+SI1heTdjY/miotDv+TROB29G2STo+RqfHRNj5qFFr80G9MfTPMiy49BMiGk0EgP7vF6a38O2YN66sX4xh0DOZgfpuP7B6l7nhT9SZbXW1vmU1d/XDjO0vbmx/8AAAD//wMA4qUtgq8gAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:46 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "34bda38a4e1cd97a5e3184adfc71a602"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746619353&engagement_id_cursor=C816CCA05050B03B0D50D57D8BF30C3A&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:46",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746676932&engagement_id_cursor=417594FC635A257BEEECA4D94B40B5A7&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+yXbW/bNhDH3/dTGH6RV01N8vhoIBhIiioGbOnQdNuLYTBUm3GMxFImyemWot99lOzESRPFERIn8jDABmTf/3h8+unuvr7p9frJ1KflyKfT8DCvHidJmfR7w94fva/BHhQ3bLNJZenHymISGxY7Jg2WRlDOubQ4ltJpymz/7dKznI1P/ZWXoljilWEZdPm/4JxgkIqDBLGyT/NscX7TjqVCCpBa2XP/18IXpc9XGsk5gKKUSwGw0mTHx8FezuZ+VPhxlk6KSsmuZlAUs2laL6rMRsezvChHuT8/++eOB7o157kvivBUjMbZIi3v2qsxZveZy6xMzkbriX9JZuWdWEKu1GdZGoKUj9aPT5I09Wf16fzsjo70+x8P318dw40DLMokr0ZNiiytxbreBz9p1FYhayVBhO2j8JGfEB0iMiTiHiefThpdYEjZd1cjxCgXxTJU7XLofr9fEgauBUcffvrNRQ2Rbyzs1/Q0zb6kvY9+nl34K31y4fPg8Oh9rQZdFEF2z7kHxbe3zZA4whUY7bgOXxZHWPMIlGIABhGLVCMkZMuQCIYQexAS0WlIOG8HybX+NSAB2h4StAmSD7+4ww5Qcr2xT6DEKm2MwAhcJLFWWllnbcgt1iigLMKNlMAWKeEIhCSY4gcp4Z2mBCPRDpO1wwtzIitOGG/DSXChQwq7kUzWG/sEThQAN8QRQhwXRCIXISEdhYg5SeKoueSi2+QEhAopje9yNhEtMRGvRwkMMWlNCfm+0OgoJeIZIJHSRIESG5FwOakjYJjSVjhLwGlNSSMkbJuQMAoYhWJwhyHZlZJrCYlqD8nGvuQ/VHJhzJhjmEodS+OsJDRyUaRiYihXVjdTwrdIiZSIUmBYPEgJ7TQlGNF2mKwdXpYTTKqSq1UyqVzgRpXW7WSy3tinZBMdMQ5achQyCHKcmtAXcEytkpaHX42ciC1zwglBD5dc3W5NRMtsIl4nmywpIaI1JZsbk45kE/EM2YRTFOEIY6qYpcpyyo0CgxFQbK2B5mwit0yJCHN4OJt0m5IdqbmWlAC0pgQ2NiYdoeRZai5D45jGTEnHIVZEGxMhoVyoukJ/IqNGStT2KKGhEKQIMQH/11wvwAmvOWFtOOFVb4J3hZNnKbo0EGwEYhBpzY2RiFAwWimBtSWxsE2gKLRFUJCgAErudDrZlaKrxoSh1pigja1JRzB5dNHV+7MS9lP/dzk6rwZe5MtTOCnL82I4GFxCmnzePyZICrWv0DGi9Qt9jPgEFB2zhHiPPgtFcPLuMkTzxel+WPF0lk7fjbP5IDmfDS7IYL3O4of1wYzGi7zI8gMsKBcEYYH2btF6Zd8E7F499WJ26Q8w2ltdpoPbF6l/khSjeZbXR1vmC1//ee24fLm8+fYvAAAA//8DAFM5e8GwIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:46 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "7f0993b031de90e8af4881bf56173ec1"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746676932&engagement_id_cursor=417594FC635A257BEEECA4D94B40B5A7&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:47",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746720170&engagement_id_cursor=A321B7053DAA6BB80243BA9971AC2F7C&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+yXS2/bRhDH7/kUgg8+xfHsY/YhwCiW3GVQoHWKOm0PRSEw0loWYpEuSTmtg3z3LinJsmNTNmHLloASOhCc/+zs66eZ+fqm19tLxz6rBj4bh5dp/TpKq3Sv1+/92fsa7EFxwzYZ1ZY9GzvmjHWGUHDWGKMi7TCWXFETkUTsvZ17VpPhZ7/00pxosjDMg86/SyEoYUoLpphc2MdFPru4aSdKg2agF/bC/z3zZeWLhUYJwUEwwHqghSY/PQ32ajL1g9IP82xU1kqxnEFZTsZZs6gqH5xOirIaFP7i/N87HnBrzlNfluGtHAzzWVbdtddjTO4zV3mVng9WE/+STqq7s1tO7zzPQpDq0frhWZpl/rw5nZ/dyYl5/+Px++Ux3DjAskqLetS0zLNGbJp98KNWbR2yUVKgeADhpz4S0QfaR3GPk89GrS48eH13NUKMalbOQzUux+6P+yVh4EZw8uGn351tiXxjYb9ln7P8S9b71U/zS7/Up5e+CA6P3td60FkZZPece1B8e9sOCbgYtURlVOzQcQNOUW64FVYanXDXCgndICQMKRLOgKyFhG81JARkN0pWDi+LCYUGE+iASe3C+0zuBiarjX0CJxEHNBSdipWVcQKG6cjGSQwSeYxgWjlhm+SEybA4ouVaTuRWcyI7YiJfjxLWB9mZEsp3gxL5DJAEMFSotizEMTcSlBQowiUXjBgkmrNWSPgmIRGKoNKSrYXk/4rr2SAhrDMkRO8GJM9RcQkudISh7JIqilAbNJImHA1KYbUVUSskuEFIpOJUKOS7XXFhN0pWDi+Jif7YtBh9io/GZO4SMIGHMPnwizveAk5WO/sEUBjRTtmECiCQ6MhxLZPwP85thIkC115yic2CwoKQ67WgbHc22YmSa4kJJx0xYX1Uu5FNnqPkckQ6EdvwECKZZsZKahLGhEEWqTvF5woSuWFIGJdkfV+y3ZCIjslEvGYu4ao7JN9X41sKiXiGTEJVEhspXBIzNDxSRhBmgViqI2uiyLZCojYHCQIPFZ8gD5RcbKshIdCxMVk5vDAmqsaE0C6YqF3KJauNfQInibYOdRK7mFKWWKShR6FRxChjCSaxbOVEb44TrhVXhGqKaznZ7mQiVTdMrvWvQQmVnSnhuBuUXO/rEyBRhBHHqOVJxAwKolBJtGgkpwRARC2QUIDNQYIAhCFo2OW2RHRsS8QrtSUNJIx1hwR2AxLx2Lak91ct3Mv8P9Xgoh54VswP4ayqLsr+4eEVy9JPB6cUlNQHGk6BE+QAQxAjpvkQU+o9fJKakvTdVYjmy88HYcXjSTZ+N8ynh+nF5PCSHq7WWf6wOpfBcFaUeXFEJBcyPMj2b8G6tD/E634z9XJy5Y8I7C/u0tHte7R3lpaDaV40J1sVM998vHacJ+A33/4DAAD//wMAnIKpWqsgAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:47 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "83738ad73a8f5cc079e76aac607b8ebb"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746720170&engagement_id_cursor=A321B7053DAA6BB80243BA9971AC2F7C&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:48",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746777753&engagement_id_cursor=8131E32D4FB3A56185875D5A7421006B&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+TXUW/bNhAA4Pf9CiPPHUAeeXek3yiRKgZs6bC028MeDCNWMqOJ1Flyi6HYfx8lO3bmRF4E17GFAX6QfXekTPozT1+/G40uprd5UU/y4jZe3DeXs2k9vRiNR7+PvsZ4zHgUm8+ayAUYaSDDkAZWlKRoEu8yJGWNJB98evFmVVnPrz/mD1VWg5DrwGrS1edMBFIZS8ooXsdvF+Xy0+O4NFZYJew6vsj/XOZVnS/WOYYIwaI2Iiauc8qbmxiv5/f5pMqvy2JWNZnq4Q6qan5btF+qLic380VVTxb5p7u/nlSIf93zfV5V8aqaXJfLon4ab8aYPxeuy3p6N9ne+JfpvH4ylxS4Tr8rizhL/fKC6z+mRZHftfvzU7i6cm9/uHz7sBGPtrCqp4tm2GlVFm2ya1cin3XmNnOutl0Afi/iy76XMBYwlvhMUV7MOkv0WIidH0eco15Wq6naknc/h8vnc+LIbcbVux9/Db5j6kff7EPxsSi/FKNf8vvyc/6QP/2cL2LBy1e2GXVZxbxn9j5m/P2mGwp7D5pF0EZLhYTkEu1YCE7AaNTQCQWOCiXWo1VqLxQ+ayhM/Zxs8k/BRMmeTNRY838xuQy/nYGSzboegsT61GZWWvA2kUJqHVKVyCQAqSyzuhOJOiYSFX0iMO9FQmeNhHoioZMi4f5I1DCQ0DdAgokmnxoQNpWBFDmXeJbSKXYJObu7Elsk+ohIUFppBBjciwTPGokUPZVsC16ZCbUtF/VhQm3LtdtmnCmT7cIe4ASEAR8EZsTKy8yrVFMSNFllvdXUfZjgEZ1oBtag7JAPEzY9Oy5zQiX9Oi5qDxM7DCWbdT0ACQnrjFcI2ifBALIDzNJ4tCgJGJ8NOpHQEZHEwwSA40ADfiwZSsdF/Tsu+r91XFKb1LElqa0XARBNKrIsypHoURnfiYSPiIS1YkCBai8SddZI5GaFXtxx8UmYgGiYoOrBpCnRYy2GwWS7sAc4URiITXBBMDmCNGOVZNqBMRkEYbsPE3NMJ5LBGqvlkDuunkz4dErUWIreSoCHoYS/ARJODTMZw/EQQccqvtFSsrPCyIySbiT2mEgsxq4LYNAdF/ZDssk/CZI+HdcaCQwDyWZdD0CSskIZXyaREEhrY5yJHY/0lh26bPdQ3SCR4ohIrJFWGUTeiwTPGokU0LfjgtdnIsV70XZc4sUd17okPpjs/oO+BpN/AAAA//+cVskOgjAQvfsVhgM36HQBrAnxSwwptSwxFNIWY0j8d1lUwknjdfY3b14yf31c5Eed7M9ToKfV3WXdVLk3CwuVc509IjRQLfKgGP+ohAccCmA4YgAS4gvlTEaCKAV5wgkW4TB2U/YajJDLWpehbBskuhrdCFqB2tNKTCZ7Y1uT4oTFBxpRQv2NXt/+b5L159FtPagUg/86pnR7SF4lbNa0ZqbWmV7Nxk/isrbd4wkAAP//AwBAAT/driAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:48 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "bc027ddb4c8b6ca1987b2e1457d0d0ac"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746777753&engagement_id_cursor=8131E32D4FB3A56185875D5A7421006B&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:48",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746835323&engagement_id_cursor=C73513518B12E64488A85741D97A5AF0&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SXwW7bOBCG7/sURs4tQM5whqRvlCgVC+ymxabtHnowhFhJjSZS15JbFMW++1K2Y3vtyI3gOJYBHwTPPxxpqE//8Odvg8FFdpsX9SgvbsPFfXM5zursYjAcfBr8DPGg2IhNxk3kAji2QhttY6cSo5SWOo4UGUxZe5PYi1eLzHpy/SV/yLIKpFwGFkUX/2tmkGgso0G9jN9Oy9nXzbg0VlgUdhmf5v/M8qrOp0uNYSZrDEoGQ0tNeXMT4vXkPh9V+XVZjKtG+RDNqmpyW8wfqi5HN5NpVY+m+de7HzsZ4n/3fJ9XVbiqRtflrKh3480ak8fCdVlnd6P1jX/PJvVOLc1L9V1ZhCL1k/XXn7OiyO/mu/NncnXl3vx++eZhGzY2sKqzabNqVpXFXOzmfcjHrdqm5GLTBdBrQa+leC/EUMBQ8iNJeTFuTcEhwtarEWrUs2pRap5ymfz9uCQsPBdcvf3jY+JbKm882IfiS1F+LwZ/5fflt/xBn33LpyHhyX1tFp1VQfbIvgfFv6/aIUGrrCbBMYGPtEUgNhQTOWfSxHnZCgkcExImlg2veyHhXkPC1A2Slf4UkAB0hgT0eUCy6usBkJCNElCpZx0BmdiLiNGF/7yOvXTet0KCx4OEJRlApSzuhaTfTiJXiD+RknXCC2OiGkxQdcEkpKghbn9BdzB5+y657AEn684eAEriYs1JFKBAzzZVAZA4csCYxD6lhFtBUUcFBRCkNnYvKKbXoBjsxslKfwpMCDtjIrdfjZ66yaqvB0AiIjAuJozD19ulklKZWkAiHSYwwGjbV9eQ0LEhYSvOGRI23SBZ6V8eEhwK2RkSsX1k7auXrBp7ACUQs0WvnbfMLgoO4T2KVIrgU0qAoVZK+IiUKCGF1qBoLyWq15SEJ+g4c4kTzVym4UTqLpyEFAqonAkn684eMnMJjkCg8yylcpQmFmJgwRa8N4mMW0HRRwQFLZKVpPbbie41KLqjnegT2ckcE+w0c5nGTuiXR5N+zFz6GdwkSoxgaQEkxBIJpSFr0uYHztqd6XMNiTkiJEoao7U08owh4Y5mwqf0EiU6Q6K2x/G+egk/g5WIyPlYGOFlOI+khBQxRKxT1p6aT3orJfaIlLDUQJqs3ksJ9ZqS4MwdZ65VwstyImEoYKioAydNihriuZxN1p09xE5cJJASZzGRwphYo6U4HA60izhSxrSBAuKYoAjBKID3z1ym16AY0Y2Tlf7lMcGNc8aTMYFfHk2efeb6DwAA//+cV8kKgzAQvfcrigdvmjFGkxSkX1IkpnGhuJDEUoT+e11axZPQ6+xv3rzD/KWSda9HIjnfpkCnUS+bdlPhXi8klNZ25oLQEDYi83IMjHKPQw5kfAsAJMT3kBMZCawUZJTjQPjD2E2ZhzciLqqm8GVbI9FV6InRhtNcN15S2WvT6iSgJGaURYy4O7H+/Ed6defRTTWoJAD3e0vJ/o6cUpi0bvXMrNW9mo1r4vLPnd4fAAAA//8DAK0JfnKvIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:48 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "86d49858cf0f8583d62ca667a8414afd"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746835323&engagement_id_cursor=C73513518B12E64488A85741D97A5AF0&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:49",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746878584&engagement_id_cursor=BAB035EA93E1088C7395C4017AB6B488&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXW0/bMBQH8Pd9iopnkI6PL8fuWy4OmrTBNHZ52EMVtaaraBPWpKAJ7bvP6X3QFKKu0PIUcf7HTpz+FPvhXat1kvZdVnZc1vcXo+qyl5bpSavd+tF68HWfWKsNelXlJCKVCMskRMiskcqgVBCAMpIYAfGT01lnOejeuEWXEYhsXphNOvs/KYWMa6O45jSv98f55Ha9zrQBw8HM62P3a+KK0o3nGa38HyrGpeF8nsmvr329HIxcp3DdPOsV0+TiDopi0M+mD1XmnevBuCg7Y3c7/P2kA/6555ErCn9VdLr5JCuf1qsxBpvKZV6mw87qxu/TQflkLrVYgGGe+UnKF+e7P9Msc8Pp2/lor66C8/cX54vXsPYCizIdV6OmRZ5Nw8F0HVyvNltNOU0ioDwDecbgC8M28DZjG5pc1qttEW2mH/00/BzlpJhNNW25sN83R/zA08DV5YdvNq6Zee3BvmY3WX6ftT67UX7nFvn0zo19w4vXtRp0UvjYhvfuE39O65EEIkIdGqWBk4xjaYS1GFoTRJFh0shaJLhHJJozRPIDbUUiDhoJA91MyarhlZmoigmIJkxUxUTicTBZLewOTiiUQEEEViQ8sVqBNCRiDYlGJrVJap3wfToxUggthNzqRB20EzLNmCzzb6EEobESbp5TcvnJXhwAk+XC7qAk1DpSiUWmExYq4JgExlpGBkOjvcNaJWKPSkghAmfPbLnooJUo1UzJMv8mSqi5kse78UNVslzYHZRIGyWGmD+JMJScg5JIJkr8NiyJhFKsVoncnxIC7U9IxMT2PRc/aCUMRDMmq4bXdYLQBmxzbOCkavFHE3UkTlYruwMUUX1OpI4NEAkKAs8EuYQYQplQHMe1UNQ+oRAxQyC3f07kQUMhauZkmX8LJkI1ZgLH8jlZLuwumy4QnKIABQT+kMKU0VKEIhA8AhNoVX80of0qQWC4fL5jPJocyaZrpkTyhkp4Wx7L0eR/bLqQYWwNYaADTYFRSawoikMPxXC0MdUq0XtUgmC0kIxtVyJeVclfAAAA///U181PgzAUAPC7f4XZgRvjvba01GQxzsLRk4knQxiyj5gNwocxJP7vduBGtmQOolO4Aq/Qvv7oe92Lro6HSRPwl07wESonpL2TOkQXXTAQJ83K/gCKoN5UKeJIKSneA1AxFYLainKkSpLTRZe8IBSKtuCoe6NvoYheQxlE0bVjwqAjE32cHP9D+8rkV4ou7grXpch0M6LYnQMcpA228lzFPQ9PKqFwQSXoIBDO9hKHqIR3VML/VUn71mSv5Gxr8uA+9QAJb4vk+nn74GgTved+sh24SOskLPM8yW4sq6SbYGbOCThCmhLmwNBmACHwFypZaAckimAmJMFgXOq3RdmrqWe8WG0W4zBeW0Gyst6I1cwzu23y4odFmsXpBAXjegQtxTjAurt/zqtRfXq2KqMJgvG1lyaH+2i0DDJ/HadVZvO0iKqL+8D6BL76+AQAAP//AwDeTC6bsSAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:49 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "da9f3703870ec5334629becffaa686c7"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746878584&engagement_id_cursor=BAB035EA93E1088C7395C4017AB6B488&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:49",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746921766&engagement_id_cursor=B6E7EE314D0BD4A80609505DFED6FF1D&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+zX3W/bNhAA8Pf9FUaeW4B3JI9Hv1EiVQzY0mLZx8MeDCFWUqOJ1Flyi6LY/z7Kn1kSuRVSOfbWBwOC746UKf98588/jEZn+XVRNpOivI4Xt+3lNG/ys9F49Ofoc4zHjDux2bSNnHEalPep01IgZ44zJVLQkCitgvRBn71YVTazy3fFpsoqlLAOrDZdvW+IECRbkizNOn49rxbv78aBrbBS2HV8Xvy1KOqmmK9zmMgoCwalhs0a1dVVjDez22JSF5dVOa3bTLW5g7qeXZfLD9VUk6vZvG4m8+L9zacHFeJf93xb1HW8qieX1aJsHsbbNWaPhZuqyW8muxv/mM+aB3sByHX6TVXGXZqvL7h8m5dlcbN8Pj+Hiwv36sfzV5sHcecR1k0+b5fN66pcJrvlSRTTztx2z2UmCtQvhX4J8KtQY4FjLR8pKsppZ4kaK7r35Yh7NIt6tdWy5Dz88XhKXHiZcPH6p9+D79j5zgf7rXxXVh/L0S/FbfWh2OTnH4p5LPj6g21XXdQx75FHHzP+ftHtRLIjNqQ9+ERDME6SA+1k2r7nQ9rpBAd0oqVWWoOAvU74qJ2w6Mdkm394JXIM2FuJxNNQsj3XJyCJv9xgbZopm4QkOKcToYKzyAlJC447kcghkQjLqAD1CSMh0w/JNv85kKDojQTNl5C8fhPOj0DJ9mCfoCRDzzJT0QRSoNg8RLyQ1tgEnUzo/lHslKgBlUQnrFgbuVeJPGolILAfk13BgZ1wO3IJ1ccJt7ROZuTaHuwTnKBLlMTM6qApSRGdcc4qZ7XIUgxKdDrRAzvRVpDd60QftROj+zHZ5j+HEuDeSqQ8kW6yPdindBOSzmVCOEgQhUZljElYKIOgBJnumYsGVGJiDsf/S2avEjpqJdRTCT2nEuzfS9CeiBL6Bkq8l5AyhcymBqXzXqQJk2YWLsvAQacSM6ASCxSbVVxorxJ11EpOZuYCXHYT6OGkLZFj/cVu8h+auULi4qiltWZkzpTJvA1CcDCCKIFw/yh2TnhIJ2TjKrucU+wmJzJzrZSg7q3kwTh+pEq+xcglKMH4MhR/u1NLbLV2KSChc84HYzqR2CGRoFUEAN9HrgMhkf1biaT/0chlTfAU24j1CWReBhae0VJKMlVgCbuUKDGcEgZFIlLB0x65TD8mu4IDO6HWiTZ9nMQSNVbq0M3kHwAAAP//nFbJCsIwEL37FdJDbm0mbdoYofglUtKYLkgXsogU/He7qKUnxevsM+89mH9fLvajTvbnKdBr1d1m/VTZ6QWFytreHDEeolbkfhHCgXGfQwGUxBRAQnKJOJWxCJWCfKQuEcEwdlPm6o8rl3VbBrJrsOhrfAvxuqg5rcBk0mnT6ZQwmnDGI8bQRq9v/zfJonl0Uw8qJYBeZEq3RPIqYbKm0zO0Vjs1Gz+Jy9l2jycAAAD//wMA2R/h0LEgAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:49 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "0a263a7d95b91c12dafcd87f56712595"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746921766&engagement_id_cursor=B6E7EE314D0BD4A80609505DFED6FF1D&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:50",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746979377&engagement_id_cursor=97ED68289DB1FD3E80D8296C63C41962&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXUW/bNhAA4Pf9CiPPLXA88o5Hv0mUVBTo0mLptoc9GEKsZEYTqbPkFkWx/z7ajq3MiVILrhL7TfDdkTTpzzx9/2U0Osuvi7KZFOV1eLhdPk7zJj8bjUd/jb6HeMi4F5tNl5GzOMsyBk0+RRAyEScOMcI41Ynz1tHZq3VlM7v8VGyqnEGj7gLrSdefW2ZUWhxr0fYufj2vFp/vx5U4cBrcXXxe/LMo6qaY3+UIsyjDYTGWNmNUV1ch3sxui0ldXFbltF6NtllBXc+uy9WXaqrJ1WxeN5N58fnm24MK+N+ab4u6Dk/15LJalM3D+HKM2WPhpmrym0m78K/5rHm4us3ybqoyTNLsnX/5d16Wxc3qdH5NLy6iN2/P32yO4d4B1k0+X46a11W5So5W+1BMO3OXU64yEZBeA71W6qPiMeixMo8UFeW0s8SMtdr5aYQ5mkW9nmpV8v5Dev54Thh5lXHx/t0fadIx9b1v9nv5qay+lqPfitvqS7HJz78U81Cw98YuB13UIe2Rgw8Z/77qVuIFhEGJQZd4T845TwmIJzZKQ4SdSnBAJQggVgvpE1bC3E/JNv8llCD0VoL8IyXn6Z9HgGS7rwcgkcQmSkWiIBYSbw1aIkRrWXky5DqR6AGRaHJg2dinrxJ91EgUqH5K2oLnZYIwBhy3J70Hk2WJGRs4kcuk3dkDoCDGzqJHpxh1FnmnNaGixEaRt0y7F2sLxQwIxSgJWoHVk1DoqKFY6udkm//8TELPpXszQTmN22S7rwcgSTxG2ttMFFmtnMJU0vATZuMzQOO6Wy4aGokzQieMhHsi4RdF0v8uQXMidwn/BCWxB0tCnBGgiwEjH95IjGjUETiV2U4lPKASYuuE8Ac9lzlqJQp6MmkLntMJfoS1E97bybqExrDbZxyrk3ZnD4DirQfAJGFHSWq1pJkTr1ESRUxZEnVCsQNDcUTqaSjHfZ1sle/bc9kXZKKhJ5PwarL7H3qsTLYbe8h1ghkTgNaxN4bilNDEll2mokyAE+5UIoMqEQCr+Ommyx61kpNourZKbH8lu/34kb6Z/IyeS1KlUgeEQFlQor3HNFUiolOXcfta9wCJGxCJAKJBZ9RJ91yqn5K2YCgm/wEAAP//zJffa4MwEMff91eMPvhmvfwySUFKlfpfDLEubWVUJdExhP3v03RTWjZaGWNCnpJLcpe7T77cD5jQFeBuTMGE9mTR6+KYKSbjw/5GTFBIgEskoiiMNpiI0JcCx1sUCxlu4+s2beCEwV9y0kkaYXyw+Z4Tf9ac8Iliwv9JTCwl0zoTSwm52ZnMgxJ+r5g8PvWGi0K91UnVH9zocxKOdV2Zlee1pEh37h6D4NKVsAeKGAXIwH8mkmYsxUrBjkuM0mXb3abMi9tFfMiLwzIrT15a5d4r9sY4zXrMS5I12pQ6QJzyTiUY8Z0LWL/Wb/HqWNdN3qoAgfNZS8FlHS2OqUlOpbaZrXWj7OSw8fy3PLx/AAAA//8DAHJIlaavIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:50 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "d69b092a68acb75480da2eebdcd7df24"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1746979377&engagement_id_cursor=97ED68289DB1FD3E80D8296C63C41962&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:51",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747022536&engagement_id_cursor=B1B307918CCBCA238B6982FE1F89BEF4&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXX2/bNhAA8Pd9CiPPLcAjeSTPbyRFFgPWtFi67WEPhhErmdFEai25RVHsu4/yP2VO7FZwbCtvcnhH0lR+vuP3XwaDi/FtXtSjvLhND/fN42Rcjy8Gw8Hfg+9pPEU8GJtOmpEL40zwKgTtBM+sitFEBCUjQKack+bi1TKznl5/zNdZJDnCamC56PLvWikOwpASRujV+O2snH96OA6GGAlGq/FZ/nmeV3U+W8UYpYxBLqXSsJ6jvLlJ4/X0Ph9V+XVZTKomUq13UFXT22LxpepydDOdVfVoln+6+/Yog/1vz/d5VaWnanRdzov68Xgzx/Sp4bqsx3ejduNfx9P68e5wFX1XFmmR+qfjr/8ZF0V+t3g7b8PVlX3z6+Wb9Wt48AKrejxrZh1XZbEItotzyCc7Y5slF5GccXzN8DXwD0wOGR9y/kRSXkx2pogh11v/GmmNel4tl1qkvHsfLp+OSTMvIq7e/fZnyHYs/eCb/VF8LMqvxeD3/L78kq/jx1/yWUr46YNtJp1XKeyJF58i/n21WwkYx52RQmTcOGkJvHaOQGv0QsOjo2iV8OMpIRAoSaEWe5XIXisB1pFJm3BiJ6ZxArqLk5TS6PqRk8vwVw+YtAd7gBPj0NoMHRnyGQvRSURgkIGzmD6wnU7EMZ1IZMCNgr1O+l1NtO7GZBN/DiWiUzUxTTWR9EKqyeZgD1FikQctUuMVIgaMXDvKBBriaKOP2z8YrRJ5TCUAaR6StFeJ7rUSpbop2cSfRQl1V4IvRMnmYA9QwoNi1qkMWFDKkUgdl5LaKqnAq3RV2akEj6hESM5QcIl7lfS85+IdmbQJp3UCvHM1aVLkUGxfW/vac/FncGKNtzLxgCijFlxH4OQlyKic8F77nU7UMZ0oo5Ak7r+bUK+dmI49lzlPz7VUgqqzEi5eSDUxz9BzRaOVNoF5Sk6E1NH5VEuCIGcis7hdWFsl+shKFCLpvUoAes1EUTcmm/jTMxFDpjszge1Oo6fFZHOuBygJPl0CuLZRAZHJNJCwDJ0nFgm5h51KzBGVoJFEIM3+ngt7jQSY7KakTTgxE9VUE9blbtKkiCG+lGrSnuwBUDLjAjFA4QMLzIKQRkcMyiKgBLN9Fi0UOiIU1WxIgIG9UHSvoeiOTZc+U9O1YMJlZyZy+ze0p9VEP0fPJSIxzoNKJURLgExn5L2kiOgoWr0LiWJHRpKE/qCamF4jUdgNySb+HEgEdEYiTt5y/QcAAP//nFbJCsIwEL37FdJDb20madIYofglUtKYLkgXklSk4L/bRS09KV5nH957zPz5crEfRbI/T4Feo+8u7abCvVlAKJ3r7BGhIWpkFuQEDlwEAnKgI0sBFMSXSFDFJNEaMi4IluEwdtP2GowbF1VThKqtkewqdCNo3dOeVlxS1RvbmgRzyiFmnGF/I9a3/5te/Xl0Ww06weC/uJRseeSV0qZ1a2Zknen1bPwkLgd493gCAAD//wMAukeNK7AgAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:51 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "11"
+          ],
+          "x-request-id": [
+            "7de8f8783eb71e9390cff5592946b04e"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747022536&engagement_id_cursor=B1B307918CCBCA238B6982FE1F89BEF4&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:51",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747065751&engagement_id_cursor=F3F9022E605B7411D7D9CC49F55B9FA7&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SX3U/jRhDA3++viPLA03GZnf2OhCrven2q1MKpXNuHqop8iQkRxKa2w7Wc7n/v2vmCAxMsCCRSHhzPzM7uzP48M9/edTrdeJyk5SBJx/5hWj2O4jLudvqdvzrfvNxr3JJNRpWkK0FzyolAC8IqJkKwzEaORUwJQBN2388ty8nwIllaaYaCLARzp/P3UggkVGlBFZUL+TjPZle35URp0BT0Qp4n/8ySokzyhY4SQitAhVLD0kd2dubl5WSaDIpkmKWjotKkyx0UxWSc1ocqs8HZJC/KQZ5cXf53zwLu7HmaFIV/KgbDbJaW9+XVGpOHxGVWxpeD9ca/xpPyni8CfKF+maXeS/l0g+F5nKbJZZ2fX93pafDx5+OPy0TcSmFRxnm1bFxkaa0c1JFIRo26lc9aEwH5IfBDgp8R+oB9zh4wStJRownrU/3D5fA+ylkxd1WbnHxyxw/r+JVrjdOTX/5wYYPrWyf7Pb1Is69p57dkml0nS/34Osm9wdMjW606K7zeA7n3Gt/fN4OitDKguPGXWyjkRnIIoyAIFTFO2ShqBAW3CQrhXAm6ARSx06BI2Y6Tlf7rY0L7oFtjgmITJsfuzx2gZBXXZ0BimXSgXcgYDxXXqKQNLHcBhpZE1DZXE7pFSKTioBkQ+igkcqchES2LiXi7WkL7RLSHhOwHJOIFKgkxUiAnnFlLIw1RFAZCGEOt78VQyB8jsYaEbRESrX1OiOTyUUjYTkNCCLajZG3wmpjQzzBvuciTMZmbsD6j+4HJOrDP4YSBItL4TzeCo04G3FFqbMR874VcNndcfGucSACU/rdeYx+LiYJ2mKz0X58SX0ygNSUU9oOSVVyfAQkTGqm0GiwakAFY33fRKLCWOeMwdI2QiK1B4ouJRMIRxONjyW5DsgrQUzsu8ZaQqNaQINsPSFZxfQ4kxhBASjVz2kgWREQFJgAhw0BHAbWNkMitQSKBaEoFAuOPQkJ3GhICrB0la4NXxoRVHRfBNpiwiiwu9gOTdWCfwQlKh4pYGkbWWBkxitr4f+gi61/x5o5LbZETJH4sYmTDZMJ3mhPZspjINyomNSUoW1OyeS45+eSOdwAT+QLVRGuHiBHBMAyddqFSEAZGhDQEw0UUNFKit0gJEUoJVBuqidhpSval5aopobQ1JVTvRy15iZbLSOMcDYhRLBDIhTQkJKEmYSQseHiaIJGwRUioUFJpDo/PJTvechHejpK1wStjoupiQtpgoqrJhGxsuXakmKwjuwmUzt+VYjdN/i0HV9XKs3yehvOyvCr6vd4NTeMvh2cISupDDWfgGx4GMAQx8lPLkMeYJPBFaiTxhxvvLSkuDv2Rx5N0/GGYTXvx1aR3jb31QYuf1pkZDGd5keVHRDJJ/BjEyMEdYJfyTcwe1FsvJjfJEYGDxW06unuTuudxMZhmeZ3bMp8l9cuV4bxVfff9fwAAAP//AwCuVFlZsCAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:51 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "deefb8a20ec7283b648b2a07eafc83fe"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747065751&engagement_id_cursor=F3F9022E605B7411D7D9CC49F55B9FA7&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:52",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747123341&engagement_id_cursor=B7BEE3A1B84A62567B1D1D91DF6C02F1&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXX2/bNhAA8Pd9CiPPLXB3/O83SiSLAVs6LN320AfDiJXUaCJ1ltxiKPbdRymOlCWRY8F1LMOAIZh3pHzSD0d+/2kyOZtfZ3k1y/LreHFbXy7m1fxsMp18nHyP4zHiwdhyUY+cORcwJAQCteCMmE68SI3jWqQ2IPGzN3eZ1fLyc3afZTgp3AzcLXr3u5KSkGkjmWZqM369KtZfHo6jNmAYmM34Kvt7nZVVttrEaKmAQ/wm2c5RXF3F8Wp5m83K7LLIF2Uz2/0dlOXyOm/+VFXMrparspqtsi83/zzJgP/d821WlvGqnF0W67x6Ol7PsXxuuCqq+c2su/Fv82X1ZC1Nm+ibIo+LVDvHX36a53l20zydX/3FhX338/m7+8fw4AGW1XxVzzovi7wJtk0dskVvbL1kE0lA4i2It8g+gJ4CTTk8k5Tli94UHrMevRpxjWpd3i3VpLz/zZ8/HxNnbiIu3v/yp3c9Sz/4Z3/kn/PiWz75Pbstvmb38fOv2Som7FzYetJ1GcOeefAx4t83/UpEQmgdGBsgADhBFo2yAi1KZhIne5XQAZUwqTURSbNViR61EqmHKWnjj6LEDFTCpkK9pOTc/zUCJG1d90ACnCuvU2VAu0RAYuOrqVwa3ViPhlwvEnZAJMJoDgql2IqEjRoJAg5T0iW8LhOkmgmoAUzqFDbl+kSaSVfZPaAYq6X2TmgnMQkoZfAAqXZMe28SNL1Q+AGhSIkIQunt3USMGkpboB2dtPHHYEI4mAkTJ8KkLeweSnxKypAUCEanwQgVCFAHklzHfpI8LkWnRBxSCTIliPPt7USOWknbC3fdc4ljKhneTNiLJ5OR7LnED0CiUk1MMJ844UICnnspwaUmBG5S+7gSHRJ5QCQaNEpgGrci4aNGgkDDlHQJr8xE1u88whAmMYVPxYtMRtJMusruczhRqMCQNSaJhxTjBQdMeITjmOSQsl4o6pBQSKGRUm7fc427m6iB3UQdqZs0TIgPZsIeb8dH2k3UD+gmOmXWptwp74V3UvBoxTKehNQpLZ701Q6JPiQSwYQAaCGeIhIphyFp44+BhA3vJUyeBpK2rnsgCSE1CYvvrrFExrOQCODeGI7MALjQi8QcDgmCip/YTbYjYaNGgoTDlHQJr8uEoDmZ4AAmdQqf0omcTLrC7uFEMCu0RK5lkClC3OXw1AaUtu4tFHifEw2HdEKoyABtP5rQuKG07XbXLZc+IpPumLEzk+4w82pM/gMAAP//nFfJCoMwEL33K4oHb5pJjMYUpF9SJKZxQVxIYilC/70ubcVTS6+zP948mPnv5Ip/VMnxMgc6rbrbtJ8LD3olobS2NyeExqAVmZcTiBn3OORA8fSggIToGnAqQ0GUgoxxgoU/Tt2Uqb0JcVG1hS+7Bom+QjeCNpzmvPGSykGbTieYUYajKGTE3an17f8mWHcZ3VSjSjC4r11K9nvklMKkTacXZq0e1GL8JK7v3OHxBAAA//8DAPQCVQCvIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:52 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "a87f4479b06b7a248671833fff9a5a2e"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747123341&engagement_id_cursor=B7BEE3A1B84A62567B1D1D91DF6C02F1&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:52",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747166572&engagement_id_cursor=53A5861486F6C106694CAF16AE5ED2F4&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+zXUW/bNhAA4Pf9CiPPLXA88sij30RKLAZ06bBk20MfDCNWMqOJ3FlKi6HYfx8lO7bXRK6FWI0M9E0w70iZ9Oc7fvlpNDqb3uRFNcmLm/hwVz/OptX0bDQevR99ieMxYmdsPqtHzhxCcJhKIM8KMgOZTcFKqUhaqZw/e7XKrOZXH/KHLKuQxXpgtejqc6M1CslWS5ZmPX6zXNx/3B0XbOMCYNfjy/zv+7ys8uU6hrURAGgApZTrmMX1dRyv5nf5pMyvFsWsrCMFP7xCWc5viuZbVYvJ9XxZVpNl/vH2n0cp8L+XvsvLMj6Vk6vFfVE9Hq/nmD81XC2q6e1k++afp/Pq0Vqa1tG3iyIuUh0cf/XXtCjy2+Z4fskuLpI3P5+/eTiHnRMsq+mynnVaLoomOGn2IZ+1xtZLNpEISK+BXgt5iTAGOQbxRFJezFpT1Bj0V7+NuEZ1X66WalLOsz+fDokTNwEX797+kaUtK+98sd+LD8XiczH6Lb9bfMof4qef8mVMOHhf60nvyxj2xLnHiH9ftStRLqhAHp0XxmWGhVDOSk45TYxib1qVYI9KUBAaDWj3KqFBIxFCdlOyTfieTNQlrJjwwUxWKbQjq43Ju1+z8wE42e7sM6CQJiIVf9tBOGUtGAeOs9RlQXGiBbdCkX1C0QRxBrO/nJhBQ9nU2wOdbOJfgglSRyZqrE6kmmz29RlIrEBwRsUaYnxq2BrClDEkPugMlcBWJKpHJMLGWbRR+6uJHTQSbboh2cS/BBKpuiM5lVqy2dhnKEkYgvfaicySlJh5mSSQgDWCgk1SaFVCPSpR8XKCSLxfiRq0ktPpuVTTc0EXJ6p2QvJEnByl58ps4ozERLEm7dF7ZBBk4sXEZYq5HYruGYokEmYvlB8919GYiE5Xk4aJtCfC5BhNV8IcvDPCsw9SAANTSpJRyeCJgmlVYvpUgjqaJdhfTnjQSk6l6WqUoO6u5JvFZBg3k2P0XA4hS8E67bzWikJISQtrfcbaOkvtNxPuEYkGisXkWz2XHjQS7FhK8IVKCY8Bx9tzPgQJN9XnCB1Xmr3NLntngkeoJcFlwZkgOVoJwCJ2XUCkyKWi/j8PrUxsj0zqAGQkuZeJHDSTyLzj1WST8H2hCKyhiC5Q6hQ5pq8bjYFWk+3GPudmImMBkcBeiMSlykDCgjkViRXRj211YqFXJ2gsKy32OqFBOzG6G5NN/EsoQdNZiTpCOenE5D8AAAD//5xUSwqDMBDd9xTFhTvNJMamKUhPUiSm8UMxShJLEXr3+mkVV0K383/z5s2/MlkWu6eS420M9LR6ubQdC3dmZqF0rrUXhPpIiyzICZwZDzjkQHFMASSc7hGnMhZEKcgYJ1iE/dBN2UcwIC4qXYSyqZFoK/QkaMVprysxqeyMbUyCGWWEUEyZv1Hrz78nWH8a3Va9SjD432NKtofklcKmdWMmap3p1GRcEufncnh/AAAA//8DAAvCRfyyIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:52 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "15"
+          ],
+          "x-request-id": [
+            "f90e683a543807dda42145200df942b2"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747166572&engagement_id_cursor=53A5861486F6C106694CAF16AE5ED2F4&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:53",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747224147&engagement_id_cursor=E3FD5308C11ABD470A8188D1A91FB79F&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+zX3W/bNhAA8Pf9FUaeW+COvOOH3ySSKgp0abF020MfDCNWMqOJ1Flyi6LY/z7Kn1kS2REcJ0oxwA+C746USP5A8scvg8HJ+DIv6lFeXMaH6+ZxMq7HJ4Ph4NPgR4zHjBux6aSJnIB3WoeQAAhPzqEml6WOgbX1HiicvFpW1tPzz/m6ypKwuAosO13+r5USKI1V0ki9il/OyvmXm3E0FqwEu4rP8r/neVXns1WOURotCAOaaZ1TXlzEeD29zkdVfl4Wk2rR2voNqmp6WSw+qi5HF9NZVY9m+Zer73cq4D/vfJ1XVXyqRuflvKjvxps2pveF67IeX422L/5tPK3v9KV4lX1VFrGT+sH553+NiyK/WszOr+HsLHnz9vTNehpuTGBVj2dNq+OqLBbJyWIc8klrbtPlIlOA4NfAr5E+ohiCGEq6pygvJq0lcijtraUR+6jn1bKrRclp+PP+lNjwIuHs/bs/gm/p+caH/V58LspvxeC3/Lr8mq/zx1/zWSx48Lg2jc6rmHbPvMeMf161I1FagJOM7JR0qQMBqDKXCkMZaZKuFYk4HhIBllGgNruRUK+RIOhuSrYFT8xENUxQd2ESSyj+9jF5/yGc9sDJdmQPgGIV+biw2bBRHp0lF0SaBJ8Ip1gBtEKRR4ZCSu/ZTVSvoWjTzckm/zmYSNmRiRwyvhAmm4E9RIkxGXsnvHWkpVcqIKDRQSSJ01KrViV0ZCVMsZOdSkyvlaiOu4l6zs2EoLMS0i/kzPUIW4lQwSB6UGlmM2OAlKUktaQ4EPvMtCLhIyKJ1x7QBMQ7kcheI0Gkbkq2BU/LREDDhLtcTZoSGtLtxdHXzWQ7sodAScF6m2BAKTPJ1gllPLBOA9skrvdWKOqIUCRKZLRW74TS7zOXgW5ONvlPz0QOscuZa8lE3l4afWWyGdgDlHgMJBXpjI21CkVoqAROUjDepIlrVaKPqUQbJmYpdyr5/8z1aEoEdlYi9m4mP8+Zi02qExOU1siZ9YJMgIQEklPALktakZgjIok8WBMS7kRCvUaCYLop2RY8JRP+CAsm8HAmy5J45rIvg8l2YA9wYlhoi2TYiyRFTkXQ1qbKZZyqTIms1Yk9ppPmihQp2p1O+n3k0rYbk03+cyhB1VmJ5JehZDOuByBxTgkZ2GGiFQAIoiQDSCCAy2zwugWJBDgmEqJ4NeE99xLdayRKdUOyyX8OJOLh95I1ErF3K3n8e8m/AAAA//+cVskKwjAQvfsV0kNvbSZp2hih+CVS0pguSBeSVCTgv9tFLT0pXmd/vHnM/PdyJT+qZH+eAr1W3W3WT4UHvbBQWdubI0IuakUeFAQOjAccCqA4pgASkkvEqYwFUQpyxgkWoRu7KXMNRsRl3Zah7Bok+hrdCFpxmtNKTCYHbTqdYkYZSRiFyN+o9e3/Jlh/Ht3UTqUY/NcypdtF8iphsqbTM7VWD2o2fhKXC7x7PAEAAP//AwAx82mBryAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:53 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "863529f85c5587871296669a9d338d37"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747224147&engagement_id_cursor=E3FD5308C11ABD470A8188D1A91FB79F&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:53",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747267403&engagement_id_cursor=CC623E5C1A76000244AF00A0E0CF9ED7&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SXTW/bOBCG7/srjJxbYEgOh0PfRIksFthNi03bPfRgCLGSGk2kriW3KIr970s58ccmllPBda3cCM07HGqoB+/o+2+j0Vl+XZTNpCiv4+K2XU7zJj8bjUcfRt9jPCq2YrNpGzlzgkMKCWdeOWm9tigUgdbsIXEkwtmLu8xmdvmpWGVZVCDuA3dF754bIikUW1KszH38el4tPm/HBVuwCux9fF78syjqppjfa5iMJGMYhTSrPaqrqxhvZrfFpC4uq3Jat0pcnaCuZ9fl8qWaanI1m9fNZF58vvn2KAP+d+bboq7jqp5cVouyeRxv95jtCjdVk99MNgf/ms+aR7UErOQ3VRmrND+ecPkxL8viZnk/f/qLi+TV7+evVhexdYV1k8/bbfO6KpfiZNmJYtqpbWsulRKkfgn6pdBvAccgx4A7kopy2pmixogPPo5Yo1nUd6WWKef+792SuPFScPH6j/c+66i89WLvyk9l9bUc/VXcVl+KlT7/Usxjwo83tt11UUfdjquPin9fdHMSmSCLQFppH1h6wZqDI5/6gIGztJMTeUROGFhKItbPmBOj+2Gy1p+CEkG9KVHiKUpev/HnA8Bk3dgDKAFPNpWZSJVUzpkMPCqikNq4TlBknZSoI1JiCIxReu1Yuykxg6aEelJCp6REqt6USH4eXkI/ARKN7FPtRCYzhYZFSJREn0jHFjnTD111AwkeERJrNLMC2G8letCQCDD9KNkk/GJMeGkmpg8mMQW3prSBm8mmsweAYuIXiU5KI6KFUCI1OfQGlVdMmMikExR9TFCINJinQBm2mxjuOXPxCTFRvdyEWzfRT85cw3CTdV8PgCQ4h1mQKQD5CEua+QyCJQ9xAjPGyU5I6JiQWLKsLe8fuWjQkFBPM6FTeomyvSFBeh6Q0E9wkkRrhalxqJBTFlIFMBk5jUEnzGw7ITHHg0RJYYQlkHYvJDhoSIRQ/SjZJPxaTITs/WfSpuBYPInJUEaudWcPAMXGactYmaVAEIJB1gJSnThtMUkS2f1vwscEBQxpw1rtBWXYIxdDP07W+lNggrI3JvBw0Biom6z7egAkkAiVYea1Cy6E+O1qNBpdKoU1QhJ3QmKPCYkW1loB+0cuHjQkwxu5/gMAAP//1JfdasIwFMfv9xTDC+9qTr6aRihSi77FKLGLWoZtSdoxCnv3JXVr8WJTwY15m+Sc5Hz8yP/8AAmHKyFxc4m4D0huIbkEc5OJSMlqnbBoLSORLmlCkzDlckX4Er6DBMMvQsIwZyzkhN+z5Bomt0sl12Dwx5iEvufpVZg4E36B5PofmIyJPcfJ45M/OCn1W5PV3nNrjlXYN01t5wh1tFSbYEsgEjKQsAXfqQA5hM9UspwrojVsnDLData527R9CVzIu6LczfLqgFRdoFeCxkDtYixMlrfGVibGgvl/AjBMT3j92j+H7LR/ui06HTsXn80UnzbSZK9sdqhMX9rGtLpfHAyPaXt4/wAAAP//AwCLzpzcsCAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:54 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "029144cb9336dfbac3c04caf78d75d1e"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747267403&engagement_id_cursor=CC623E5C1A76000244AF00A0E0CF9ED7&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:54",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747325010&engagement_id_cursor=74FBB7C2EFA48F987CB3A3A6C59E25B0&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SX32/bNhDH3/tXGH7IU9Mcf5MGgoGUxGLAlg5L2z0Mg6HajGMkljJJTrsU/d9HybGUH3YcwXUivxG67/HIIz+64/c3vV4/nrikGLpk4gezcjiOi7jfG/T+7n33dq+4Y5uOS0ufEksNEtRKE1ANLGShYJhQFCnCkBH9twvPYjq6cEsvRQlCt4ZF0MV3wTlGRCpOJBG39kmWzq/u2pFUoAioW3vm/p27vHDZrUZy4aMzBlLyZYz07Mzbi+nMDXM3SpNxXir5cgV5Pp0k1aaKdHg2zfJimLmry/8eecC9Nc9cnvtRPhyl86R4bC/nmK4yF2kRXw6bhX+Np8WjWGKZgMs08UGKZ+tH53GSuMvqdH6PTk/1+19P3i+P4c4B5kWclbPGeZpUYl3lwY3XasuQlRIDZofADhH7iPgAyIDyFU4uGa91Yd7rwdXwMYp5vghVuXz4IzpZrfEzV4rTD799jsI1oe/s7FNykaRfk96fbpZeu6U+vnaZd3h2YstJ57mXrTh4r/jxdj0lSjNJKDPAA8IoCgOg3CJsBbbKhhCspQTvmBIsYQMlotOUcNaOklr/GpQw0pISOmByTyipE7sFJZzaAGEllK8iivMg0tKgEAchN1ZbpdZSQnZICRcCuGL1/lZTQjtNCcItMWkcXpYTDAPAAwItOCld6ICwTZycRH91AJMmsVtwYpkEYxghBnSEseaUSc6BmnKAmV7LCd0lJ5QLJZUgT3KiOs2JbNlzydfpuRaUtKomC0ow7Acl8ie0XMwKjwnBHIRhWiDAWDHf7Eijlcb6YSYaSNguIfHFRGJZt5SrIUHQaUq4akdJrX95Soi/9a0pQfvyMqkTu00tIURaFCAacSspDTURggD4m8yJRYKvxYTvEBNJmcCKwl73XMDbYdI4vCQn/CNU1QTjZ3OycKED2Pg26UY1aRK7BSeCoyAiGiRFXDMqBaLMkNAKwhTSKlrLidghJ4pISRTF6ElOeKc5ES17LvEaPdeSEiJaUkIGjO4HJeIn9FwcExxpYwMhIhMGUSiVxYYqE0gjCFr/MJG7LCYeUE4YerrnEp2GhLN2kNT614CEPr/lWkJC1X5AUud1C0gMMUYHLNQQ0QhZQ62OlFYhl0FIBX74u2ggUbuDhIKgAhhsqCSk05Ag1JKSxuGFMaElJoi1wYRWL5OHr9aOYtIkdpuOCxizEgU8kNxiHhlDNFLaWqMkR8DWcYJhl5wQRhVh8DQn3S4mErXDpNa/BiWkVTGhVcf18Gp0lJI6r5sg6f1TCvuJ+1YMr8qJ59niEM6L4iofHB3dkCT+cniGQQp1qOAMKGIUYAR87J8HIxZj5+CLUBjF7258NJdfHPodT6bJ5N0onR3FV9Oja3zU7DP/pTmX4Wie5Wl2jHyJIFz6mQ/uwbq0b+L1oFp6Pr1xxwgObu/S8f171D+P8+EszaqTLbK5qz7WjovX3Jsf/wMAAP//AwBm+NEdriAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:54 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "84acdeb922670265276c0890eeba17b1"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747325010&engagement_id_cursor=74FBB7C2EFA48F987CB3A3A6C59E25B0&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:55",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747368154&engagement_id_cursor=7055F81C6C86F26EBB3A19AFFB986105&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXS2/jNhAA4Pv+CiOHnDabITl8GQgKUqIWBbbJotm2h6IwtLbiGImlVJKzbRb73yvJtpSXH4Lr2L4J5owoDfWZw+/vOp2jcBjFeS+Kh8XFuLwchHl41Ol2/ux8L8aLiEdjo0E5cuShtUL6COh4YB1nwtNKGuszqx2if/R+mpmP+jfRPEsjo2Q2MJ10+rsUghKmtGCKydn4ME0md4/HidKgGejZeBr9PYmyPEpnMUpIBImSsSYmuboqxvPROOplUT+JB1kVOX+CLBsN4+ql8qR3NUqzvJdGd7f/vsiAJ888jrKsuMp6/WQS5y/Hy3uMXhvOkzy87TUP/i0c5S/mEvMC3CZxMUm+dnz/Oozj6LZanV/c5aX5+PP5x/kyPFrALA/T8q5hlsRVsKnqEA0WxpZTVpEUKD8BfkLEF8Au0C7SV5KieLAwhXVRP/s0ijnySTadqko5d3+8HlLcuAq4vPj0u/MXzPzoxX6Lb+LkW9z5NRon99E8PryP0iJh7bqWN51kRdgr615E/Hi/BIl23A8EWqmZFxAuQAdaolPWBUpTvhAJ3SISxgVBApwtRcL3GgkhrJ2SJuGNmaiSSbPS6zApUrBL1GEwaQq7gZNAauU8i84GLmDc+BD41oHwGBOBMWShE7ZlJ4JpwZc6kXvtREE7JnX8LpQga60E2ColF5/d+R4wqQu7gRJtfGOZJT7jQK2myuNGGwy8ogdjlONCJbhNJYoDKFHf43Uleq+VCNGy5RI7VMJbtVyqbLn4gewldV03QILcN56SVCrPBNb40iJzlGpP6cB5cvG5hG8RiaAKuCZsecuFe42EAGmnpEl4WyaElt88adNylSnY5eIwmDSF3cCJUiglIY540godMGckBIAmkKgVsXShE7FNJ5xQALmi5RJ77URiOyZ1/C6UUN1aCa5sufZDSV3XDZAQDQYCbqTvcc8WjZb1hK8xUEi5UMYtRCK3iISjAEKkXL6Z7DeSWvi6HRffIRKGrZEwfRhI6rpugsQn2oFFv/huBUpA5fsAAgRFIwzni5BwtT0kQkilNQehlyJhe42EtDyWkF0cS9TsWIJqbSRqdiyB5yfWF0guPrvz5Up898l92X7H9T8cTLwAqfWtAt/X0i/2FeeM4sQjBgMD6nktGiZ6e0wkcGRaCn3Ie0mxF7Z0Uie8LZRya6BdSltAme4m5EB2k6awGziRPitYoHQ+Fr2WsmiM0J7kllCnufMWORGwXSdIKOFyqRO9104Uacekjt+FkuaUsbaS1dvJfiip67oKSeevMvAojv7Je3fljSfpdBGu8/wu656ePrA4/HpyRUFJfaLhCpBwBOiDGDCNfR7SKIKvUlMSfngoZouym5PijYejePihn4xPw7vR6T09bd4z+6lZl15/kmZJekYkSi6KTYIdP8E6H1/l9bh69Gz0EJ0ROJ59S2dPv6Oj6zDrjZO0Wtk8nUTVj3Vi9d8C7378BwAA//8DABSJ6zKtIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:55 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "878cbd5749818f8840136014105acc9f"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747368154&engagement_id_cursor=7055F81C6C86F26EBB3A19AFFB986105&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:55",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747569763&engagement_id_cursor=7D385147ED46D98B4AA69C75B12E95EC&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TX3W/bNhAA8Pf+FYYf8tQ0x68jaSAYSEksBmzpsHTbwzAYqq04RmMpk+R0S9H/fZRsy/myY8H1bD9F8B1FidQvd/z6ptPpxqMkLftJOvIXk+pyGJdxt9Pr/Nn56uM+40FsPKwiXcdsFKF0VlgTSmEspUyDJdJKqlzEu29nI8vx4HOyGKU5QzIPzCad/S4RKWFKI1NMzuOjPJvePowTpUEz0PN4nvw9TYoyyec5CiVqSZEBCjbPya6ufLwcT5J+kQyydFjUT7F4gqIYj9L6pcqsfzXOi7KfJ7c3/z4bAY+eeZIUhb8q+oNsmpbP49U9xi+Fy6yMb/rLB/8Sj8tnc+FiAW6y1E9Sbpw/uI7TNLmpd+fn6PLSvP/x4v1iGx5sYFHGeXXXuMjSOtnU65AMV+ZWU9aZFKg4BXFK1EdCe0B7gr4wKEmHK4ewntBPPg0/RzktZlPVQz78El28nOPvXGdcfvjp9yhcMfWDN/st/ZxmX9LOr8kku0sW+fFdkvsBGy9sddNp4dNe2Hif8e3taiWSmsApAaGKQPu/1NKIC2kIOKDM2pVK6O6USEoAZZW2Vgk7aCUERDsmywH/sxOsnBDWxgnWTtSROFmu7BZQQotOS27QqYAjiQIaBegQw1BZpQOzEgrbJRTOGSjG10PBg4YisZ2TJn8fTKhqzYQ/7TSeMbmI/jgAJc26boGEaR2Gzn+3xkiitWMG0QiutRXaoQ5WIuE7ribaF6xjRoItkeA+kTDeHgkcSS3B76BEqqqOUF83rOSBipQiRAcsQEvROFytROxQCUfBkTMi1yrhB62ENG+4cc+l9+KEQvXRE9LCSTVE9OBYnCxXdgso1BrqXCiBEk4VBgxoGITeig9g6NhKKLhLKEQB9ZOsh3LY5URBOydN/j6YUNmSCe9xeSRMmoXdQglQajwUyajl1lkGvogYbQwPDdcgn7afSyVyh0p8sZIgoTl5vaxEHrSSZoE2bbrkHpW0arrmSshxnEyadd0CidJUA/BIqyhUQjkbUuCAkpqo0uJWIlE7RIJMghackrVI2EEj0S1bLr2Pjkt/BKhOJsv26VUksyHelT6SUqK/Q8NFTBiFkbDAFeMOjAxZ5IgLUJEQdfj0/8VSid6hEm9EMfrayUQctBLJ2ylp8vehhNDWSigeRylp1nULJJoKZE4oDK3voVAI4hxjGAiUgFaZVUgk7BAJcuBac8HWIuEHjaQ5tm3ab+E+kWx+KmmQPD2wHmopaRb2NSWdv6rEbpr8U/ZvqxtP89kuXJflbdE7O7tnafzp9IqCkvpUwxVwIjjAAHDINB+ImCYJfJKakvjdvZ8tKT6f+jcejdPRu0E2OYtvx2d39Gz5nsUPy43pD6Z5keXnRHKJhGomTx5pXcRfA3tSP3oxvk/OCZzMP6bzxx9S9zou+pMsr7e2zKdJ/WMzsPqVwJtv/wEAAP//AwAULcc4riAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:55 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "11"
+          ],
+          "x-request-id": [
+            "0d820ba3db173e0c24aad7a5ceae1d9a"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747569763&engagement_id_cursor=7D385147ED46D98B4AA69C75B12E95EC&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:56",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747612937&engagement_id_cursor=92563F586DB3676551FF336C56706B8A&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXX2/bNhAA8Pd9CiPPLXB3JI+k3kSRKgZs6bDsz8MeDCNWMqOJ1Flyi6HYdx9lO3JWR0YFz7H1EEDI3ZESqZ+P+vLdZHI1uy/KZlqU9/Hisb2cz5rZ1SSZ/DH5EuMx41lsMW8jV5ShtehIADILo5TOMtIGvAfnhA9XbzaVzeL2Q/FUZaXQuA1sJt38XzMTCmPjQEJv4/fLavXxeRyNBSvAbuPL4q9VUTfFcptjWMfppTZCGrXNqe7uYrxZPBbTuritynndZsqnO6jrxX25fqimmt4tlnUzXRYfH/7eq4D/3PNjUdfxqp7eVquy2Y+3YyxeCjdVM3uY7m7882zR7M2FYLbpD1UZZ2m+veD2z1lZFg/r/fkx3Nyk776/fve0Ec+2sG5my3bYWV2V6+R0vRLFvDe3nXOz7UDqLai3aH8BmYBIkF4oKsp5b4lKAL56OeIczareTLUuuQ6/v5wSB14n3Lz/4bfge2Z+9mC/lh/K6nM5+bl4rD4VT/mzT8UyFnz7wrajruqY98LWx4x/3vQ7UWTYZ9aBddGLdHmWsQngtCbLJuNeJ3RKJ5pQkhDioBO+aCd6IBN9TiVkBiqRifz61dhT8v6ncH0BTPT/oMRrFpQJQp8iOWedl5I4lS5IcJnOe5WIUyqRSnDb4A4qMRethHmYki7/HEoED1dC4+gl3boegQTSFHKVe/AqKEmQgcpMlpNm7YLe/cTsIZGnQ2JAxyH0DuIoj1w0UMmu4JWZmAQoEWoIE7NmguNgslvYI5ygR6c5DZaV9QQe05wl5uiJZU5S9jpRJ3SCHHtJO8lBJ/ainRg9jEmXfw4lyg5WQmM5cnULe8yRKwiTWi3I+1SDCVqC9sEblWUanejvJnxCJaCUlWiMOqgE8aKZsB3GpMt/fSYiQRjMBO04mkm3rkcoCfFTxCkZD16aKNUuV07nRJLjX3ypQ68SfUIlsVMZMgyHlaiLRhKfc+CZqyt4XSZIbTchHMCkLRkPk93CHuGEJSH4IAGtCyIoG6Qmz0pkzCkH1+vEnNCJBCEUoxr1mUsMY9Lln0OJpMFKQI1DSbeuRyERLosnLiXzYGL/sJKNNLkPmTMGhO5DYvCESFixAsNdsxwlEhyIBM+DhNdIhpy42pKIBMfyYYLHKzECGFKQwkOOijDXjMbnBnUWrN/7RtspoVMqQVCaxt1KWA9T0uWfRYkZqEQk6gyt5F8AAAD//5xXyQqDMBC99yuKB2+aSYzGFKRfUiSmcaG4kMRShP57NV3EU0uvsz/ePJj56y9hP4pkf1oCvU7dbD4shUf9JKG2djAHhKaoE0VQEkgZDziUQHFMASQk54hTGQuiFBSMEyzCae6mzCWYEVdNV4Wyb5EYGnQlaMVpjisvuRy16XWG2fzpMIiT1N+I9e3/plffjW6aSWUY/NcuZds98mph8rbXjlmrR+WMn0R3psLu/gAAAP//AwCmT8L+riAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:56 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "e4db8329ce888269ac7ac009ae99a3c3"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747612937&engagement_id_cursor=92563F586DB3676551FF336C56706B8A&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:56",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747670568&engagement_id_cursor=83060A043D0F1521F7618DF817CE9D26&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+yX32/TMBDH3/krqj2DdLbvfHbfUsdBSDAQG/DAQxWt2ajYEmhSEEL87zhZf4xtKY2qsBZ4s3rf8zlnf3p33x8NBkfpRZZX4yy/CIurejlJq/RoMBy8H3wP9qC4YZtOassRe9BonfA+Yk/Oo3BCANCII0fOwdHja89qevYxW3pZVEYtDNdBr39nraVQxupg5oX9YlbMP920C2PBKrAL+yz7PM/KKpstNEazYW3IIiAtNMX5ebBX06tsXGZnRT4payUuT1CW04u8+aiqGJ9PZ2U1nmWfLr/d8YBfznyVlWVYleOzYp5Xd+31HtP7zFVRpZfj9cG/ptPqTiwBywxdFnmIUm3vcPYhzfPssrmfF/7kJHr67Pjp8iJuXGFZpbN627Qs8kYcNZnIJq3aOmajlCDpCdATYU8lDEEOlbrHKcsnrS44FPrW4wgxqnl5HapxOfbv7peEjRvBycvnb33cEvnGh73JP+bF13zwOrsqvmRLffolmwWH7RNb7zovg+6eqw+KH4/bObHoTOIUxdKwd7G2yqIAob0m5BhGrZxQj5wYaQ1bzbyRE95rTjR1w2SlfwhKCDtSooZkD4OSVV53gGRkFHmgeKR0ZCx7L0aMXiVslfTh77wVEtMfJBYAhDRCbi4m/yHZFRIJp9C8eCm3hWThgkPJv4Pk5St//JdQ4h1rmejQ4TjrJSVeRNIrBMnOx5FIWimxPVIiDYU+UKDdSMm+t1yia8slHoYTrIsJbN1yLVzUEPEwisk6sTtwknAoGt4GJGIGdspGTDpxSDbUFyVaRxMLfXKiVWBFmM2c0F5zwtgNk5X+IShZTxlbU6JuP419rSarxO5STawDBIUiiTA2yqMjr3FERuhYSC1bKRE9U6KYlNpIid5rSg6l52oo6dZzNZT8Uz0XWaMEyTANSAOxjGNwnlGAUyPLQulWSmSPlBAYEbSrPQ6y55LQDZO1wx/mxDTVhLtwYurZRBwKJ+vM7gCKjnxobygRPg5jSRSJCGLrEVCLGEDbVlBUj6Agh+EonIE2gmL3GhSjunGy0j8EJsp2xgRudxr7iskqsTtQItUoMpENaBARUmi+HMbISGQYnTOtlGCPlJBiFTbBzaPJflOiuRslK31PlPwEAAD//9SWXUvDMBSG7/0VsovedfloPgdFKlkvvfVKSlazrcjakrQiBf+7aacrQ7AUmbjbJG+S857zcM6PlBAxk5JoRemVUHIy9heUJAqyJFKJlOlaCUYUS8U9YSlGlETqmxUjJfSClHDEBZYIXfXQBck8TEbB33KC8Oyhq5f4boKmOHlYP/4DTEZjpzi5feoPLkrz1mR1f3Nrj1nYN03tVgB0Uak34RZDwWUo4RYSjwmEOWTPvm/kVGNj4IZLjPSy868Z9xL6kHdFuVvm1QHougCvGIyBursxMVneWlfZGHHCOcG+VQRnvH7tTyEbDF93RWdiBIPPYorPC2mx1y47VHZIbWNbMyyehEfbbt4/AAAA//8DAM85psSzIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:56 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "12"
+          ],
+          "x-request-id": [
+            "95d13ef567c73cc1164e373372bc202a"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747670568&engagement_id_cursor=83060A043D0F1521F7618DF817CE9D26&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747742537&engagement_id_cursor=AD06A3DA99FED864D6F8B46F21543D55&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+TXT2/bNhQA8Ps+hZFzC/DP4yPpGymRRYEuHZa0PexgCLGSGU2kzpJbDMW++ygrsjLHci24imXsJpjvkTSpn/j4/ZfJ5CK5S7NylmZ34eGhepwnZXIxmU7+mHwP7SHiSdtiXrVcGMaEZ2A4lwy51sLEkeBCEBYpCZZdvKozy8XN57TJ0sA1PjbUg9a/S0RGudLIFZeP7XfLfPXlaTtVmmhO9GP7Mv1rlRZlunyMUSi1DJNSHGXTR357G9rLxUM6K9KbPJsX696aGRTF4i5b/6kyn90ulkU5W6Zf7v9+lkH+M+eHtCjCUzG7yVdZ+by96mOxq7nMy+R+1k78W7Ion8+uWaD7PAuDlAfH3/yZZFl6v96dX93VlXnz9vJNsw1PNrAok2XVa1LkWb2V63VI552x1ZDrSEaYeE3Ea0auKZsSNuV8R1KazTtT+BT01qsRxihXRT3UOuXSfdodEjpeB1y9f/fRxR0jP/ljH7LPWf4tm/yePuRf0yY++ZouQ8LB61p1uipC2I59DxH/vOpGopwBgxqpJIwSr4yx0nntdIRaMUM7kcihkSipzxkJin5INvEnQaL7I4HzQLJZ1yOQOOe0Z84hSO4jigDKo6fKOyepoKoTiRoQiYZwipEQtRcJjBoJJdBPSZvwwkywYsJUHyYhBaZ0u8wYKZN2YY85TCJPw5khmBDSRNI4JOEVDUw8Z94S2+lED+0E+eY7sNsJjtrJuVRcayXQq+LC6jAR/6OKi3tJjScKjIxp7LSNTThFpHNGEcac6EASPvUDIxGcgj5jJNgTCZ4USa+Kq0ay/WqMFAn+BCRegohjIS2PlbHUkQiIxMiCVxFCtP25aJHQwZAoKoRgvArbi4SPGgklsp+SNuElmdBrRnoyqVNgyvE8mLQLe4QTK3yot6g1obwC7SIpgYfXlFISo7CCdjphAzoBTRSR4qwPE6n6MdnEv7wSPiWitxLGz0PJZl2PuZYYpxVosIo7QgHRxmAgtpqHe4nQcScSPiQSpEEhaL4XiRw1ks2d6tCKS5wQCT38WtIgoeo8kGzW9QgkxEbEmpijjwGFJiBNhDQC6b2yUbT9uWiRwIBIJAYiwYnYi2TsFVdPJW3CSzJh16SuuMjBTOqUcJb88GLy/jd3OQIn7coeAYVL5FYgKOKFihwSgeEgkTqw0RDjdvXZQhFDQpGoiZBsP5SRl1w9bybyFBeThok4vORqmFB2ktPkXwAAAP//lFdLDoIwEN17CsOCHXRaiqUmxJMYUmr5xFBIW4wh8e7yUQkrdTv/lzczmfn/5Pr1L9mfJ0NPq7vLuilwbxYSKuc6e0RoiLTIg4JAwnjAoQCKYwog4XCJOJWxIEpBzjjBIhzGbMpegxFxWesylG2DRFejG0ErTntaeclkb2xrUswoSxjBLPY3w/rWf5tXfy7d1oNKMfivXkq3feRVwmZNa2ZmnenVLPw4Lrtl93gCAAD//wMATMikgasgAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:57 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "54ea283cc5588f8f885a443daf31561c"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747742537&engagement_id_cursor=AD06A3DA99FED864D6F8B46F21543D55&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:58",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747872175&engagement_id_cursor=3763B56480F58CE605693F79D4694D66&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXX2/bNhAA8Pd9CiPPLcA/x7uj3yiRKgZs6bBs60MfDCNWUqOJ1Flyi6HYdx/lxHbmRE4ER7XsJ8F3J1KUfuDx+0+j0dn0Oi/qSV5cx4vb5nI2radno/Ho4+h7jMeMB7H5rImcWQ2YpTr1iVfOZcGIFK3IGHQmA5M7e3NXWc8vP+frKgsg8D5wN+jd/4SopGaLmjXdx68X5fLLw7hkK6wW9j6+yP9e5lWdL+5zGFkyWEtMsM4pr65ivJ7f5pMqvyyLWdVkbmZQVfPrYvVQdTm5mi+qerLIv9z886hC/G/Ot3lVxatqclkui/pxvLnH/KlwXdbTm8l24t+m8/rx7NbTuymLOEj94vzLT9OiyG9Wb+fXcHHh3v18/m79Gh68wKqeLpq7TquyWCW71Trks9bcZshVphLKvBXmrVJ/CDEWeizkE0V5MWstgbGgnU8jjlEvq7uhViXn4cPTKfHGq4SL97/8FXzLyA8e7M/ic1F+K0a/57fl13ydP/2aL2LBi9e1uemyimlPvPeY8e+bdiRkMPOsrDdIxA4dexV/SUgQnAxZKxLqD4kScSqCgM1eJDBoJHKzQi9Usi34wUziB6/GynZhAg0Tic8xef9bOB+Ak+3KHgBFxr0keIE2OFJp1OJ9GqIWCYAaWLVC4T6haGmRUOq9UGjQUKijEzomE8DOTIQ+jd2EXgEJaZ9hwtoY50ICqTEUjPdB6oyV9qIVie0TSdSJyJvnO0Uk2BEJHhOJ0d2R7H4aQ91L8BWUBEYkadmkMhEoYrdjU/LCZZiCZGnalEjRoxLQBCLuJ/uVDL3ngm5MtgU/2Ak3TiR1ccIrJ/JEnGxX9gAoqcwQtFGOUraWmaSBBBODCoRU2LqdSNknFDAgic3+ngsHDYWwm5NN/jGYaNWRiR4DnwiTzcIeoIRRaO8jEBGSJDinfSKVwSDj+cRyCq1KVJ9KhEDUVp/yyQRNx6bLHFOJ7a5k99MYqpLNwh6yl1AKSWJ96lKVphIzxSFj53zi4lYCu4e0rRLdo5J4KCLJQu5XogetRAru2nTxUZxI1ThR0MFJUwJjqZ5zch4+DIDJdmEPcJJozgRxgCxjbwlQh3jwwOCkIWXD7lJsnUCPTsiCFvHItP9wMvCeqyMTOqYSEB2V6LE5mZ7rFZRIYGWFBi1JEnnrAViHVEPQMiORtioxfSohtoD8zG4y8J6LuinZ5B9FCXVX8mzP9dp7yX8AAAD//5xXyQqDMBC99yuKh9w0i0uaQuiXFIlpXChGSWIpQv+9UYviqaXX2Yc3j5n58+SiP5LkeJ0MA62eLu+nwINZQKid6+0ZwjHWoghLgk6UhQyVyJPAfwcSZbeYJTIVRClUUEawiEafTdl76DuuGl1Fsmuh6Bv4IHDr0142XHI5GNsZjmlCGU7jjIIdWVf9F76CuXTbjIpjBD6zxPdzFNTC5m1nZmSdGdQsXB2XDXx4vQEAAP//AwBzb9mxsCAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:58 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "469ae8c8c80458a64d5aca07b487e49f"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747872175&engagement_id_cursor=3763B56480F58CE605693F79D4694D66&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:58",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747915367&engagement_id_cursor=14829034317177D9D4483EC34E31F70C&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXS2/bRhAA4Ht/heBzAszM7uxDNz6WQYHWCeq0OfQgEBbtCrHJVKQSBEH/e5eUTDmyKZmQadEHAYRmZpdc7ofh/vhlMjlLr7O8mmX5tb+4rS/naZWeTaaTvyc/fNxn3Ist5nXkTNgkBhJGCQMCIhU77SAJlAusi5WUZ2/WldXi8nN2V2WlRLUJrCdd/6+VIhTG+sGE3sSvl8Xqy/04GgtWgN3El9m/q6yssuUmxygjCA2w1AY3OcXVlY9Xi9tsVmaXRT4v60x5dwdlubjOm4eqitnVYllWs2X25eb7gwr46Z5vs7L0V+Xssljl1cN4PcbisXBVVOnNbHvj39JF9WAubJ/wpsj9LNXTCy7/SfM8u2nez+/u4iJ49+v5u7sXce8VllW6rIdNyyJvkoNmJbJ5Z249Z5NJQPwW+C3RR1RToCmqR4qyfN5ZIqfAO5vDz1GtyvVUTcm5+/R4ih+4Sbh4/9tfLu6Y+d6D/Zl/zotv+eSP7Lb4mt3lp1+zpS94+sLWo65Kn/fIq/cZ/73pdhJjEvrdGwApJ6SUbAKmxLnQBIa1ijqd6AGdoAXth4D9TvSonWjTj0mbfwolQvRUIqaMr0NJu65HIHGGLQVShTKB0LEX4nlE1lpCGwDrTiRmQCSEYBQZyXuR2FEjUaofkjb/FEgk9kYid7fGSJG063oEEiME+g5CIBw7sEonzJ4AsWa/1eOgE4kdEInUSMgKxV4katRIUPZUsi14WSYE9Z4H6MGkLuEpqUNM3n9w5yNwsl3ZI6CEfmOHjDYOVUSgE0XaQ3FkNInEiN21aKEQDAnFGJRMWu+FguM+m9ieUOwpnQjZ2wnCK3Fin4FJrP2+dazJsosSQzKxJgwSoIAojOTu5+eWCQ7JBBk1GbX/ZIIjP5pgPyZt/imYcP92AgePJiNh0i7sEUyQ4sjpmJ3xv1BjzFb7jx7fV4hcCKKTCQ3IRFltLSje/9k17maCQP2YbAte0on4CI0T5Cc7WZfI6YOD60hPJ9uFPcJJxBRzjF5E4LsKk2So9ygZB5FFvbsUWydiUCcGjWbc/9XFo3aiuR+TNv8USsj2ViLla+kmfLwS5RsH2Vih35yRs/7KsY1iKSKZRKxtpxI5oBIN0gDaA0rUqJWonkrUKZWI/r1EHjyajKOXqGdAQnUriUwE6PxJJFQQKmllHBuMVIQYdCLh4ZBIJKHQinaO19hKEGU/JduCF2Yim2Yi+jCR9dEED35yPW8z+R8AAP//nFbJCoMwEL33K4oHb5rJYtMUpF9SJKZxobiQxFKE/ntdWsWT0Ovsb948mP9/rmWze0I53sZAr9Yvl7Rj5c7MNBTOtfaCUE9rmQYZgTMXgYAMGI4YgILTnQqmIkm0hpQLgmXYD920fQQD5Lys81A1FZJtiZ4ErUDtdWUmUZ2xjYkxZ1xwCkD9jWB//j3N+tPotux1jMH/XlO8vSSvkDapGjNx60ynJ+OSOL+qh/cHAAD//wMAA/7/abQgAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:58 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "8cabccd271b4dcc441c726b636808290"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747915367&engagement_id_cursor=14829034317177D9D4483EC34E31F70C&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:59",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747973003&engagement_id_cursor=252D5C8C01E2BCB60B6494DD81C6C11A&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXW2/bNhQA4Pf+CiMPeWoaHl4OSQPBQIlUMWBLh2VbH4bBUG3FMRpLmSSnW4r+91GyI+XmuILnRIZfZPMcUiL1mYdf3wwGB/E0SctRkk79xby6nMRlfDAYDv4cfPXtPuJO22xStRxg4CgRAQuAC4s8VNU3FBocaqY1HrxdZpaz8efkNktzTnHVsBx0+btEpMCURqaYXLVP82xxdbcdlCaaEb1qz5O/F0lRJvkqRqHiBIUgnAq2isnOz317OZsnoyIZZ+mkqHu7vYOimE3T+qHKbHQ+y4tylCdXl/8+yiD37nmeFIW/KkbjbJGWj9urPmZPNZdZGV+O2hv/Es/KR2Mpuoq+zFI/SPnd8eOLOE2Ty3p1fnZnZ+b9j6fvb5fhzgIWZZxXvcZFltbBpp6HZLI2thqyjqSEiiMijij7jfAhYUMOTyQl6WRtivBZD14NP0a5KJZD1Smn7uPTIb7jOuDsw09/OLtm5DsP9nv6Oc2+pINfk3l2ndzGx9dJ7hO+e16rTheFD3ti3X3Et7frkRgKlgPBMLIYcRlBaCNwmrtQG+ftrEUid4yEMtnEPI1E9xoJym5ImvjXQCJIRyR8KOQmJB9+cac9UNJM7BZKbOCFWBfYMELmtw9EZzAyYRA6hgB6rRK1QyVcCoXERz2rRPRaCVDoxqRNeGEnakjoELCLE1U5gX1x0s7sFlAkpSFGgdKWWipDbiPDeOSUMtoQC3QtFL1LKEgkFUqJZ6H0vObS3Zw08a/BhPHOTDbXXD1h0kzsFkqUP5VoANSBBCuc0ZFDySXzBZgOiVlbdDGySyUMJEhB4FklqtdK9qXoqpVw2lGJP8w8rDT6quT/KLqkk8yI0EWaWERJUFLtmLMGhS/C5MM/jFYJ7FCJ4siF9F09q4T3WgkQ3o1Jm/CyToBWTkSX3aRK4UOmNjk5dR97wKSd2G2ciIALakQkJQstEB0FOtIy0CGGympc64Tu0olArYFvqLmw104kdmPSxL+8EjYkurMSKvZkN2kmdgslIlQ6Usj8ScARpkCE4JQBZZHZCB+d0lolbJdKpP8w2FBz9ftkgqKbkib+NZSA6K6E7Mde0szrNgcTAxYiTnx55ax/NYVlxqERIgwpCgVrkfDdIREUqdJKCPksEtFrJADQTUmb8MJMsCq5gHVhghUTwveDSTuxWziBSDPDA06MEdwCkxBK7pwJ/YElsvJh9dk6Ebt1ojluctLvzUSRbkya+NdQwkhHJWwo9mQzaeZ1E5LBX1XgQZr8U46uqo4X+XIRLsryqhgeH9+wNP50dE6JkvpIk3PCQXBCxgQnTPOxiGmSkE9SU4jf3fjRkuLzkX/i6Sydvhtn8+P4anZ8TY/b5yx+aNdlNF7kRZafgOSKAIIgh/ewNu0bvB7Wt17MbpITIIerd+nk/nt0cBEXo3mW1ytb5ouk/rFJXB7n3nz7DwAA//8DAEwOL+OvIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:59 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "08642bb7a06b666e09ffce08f9162244"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1747973003&engagement_id_cursor=252D5C8C01E2BCB60B6494DD81C6C11A&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:13:59",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748016150&engagement_id_cursor=1F93A4B40AA54D1371C74EEAC3A5FD78&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+zXS2/bRhAA4Ht/heBzAszszL50I3eXQYHWKeqkPeQgCBbtCrHJVKQSFEH/e1fUM7Ypi7AV0UV0EaGd2V0t+WGGX38aDM7G13lRj/LiOl7cLi4n43p8NhgOPgy+xvEYsTM2nSxGzlin1jJloJwQpCHLGFEkFl38RnZnr5aZ9fTyY77OssykVgPLRZe/a6UEkrGKDOnV+PWsnH/aHUdjwRLY1fgs/3ueV3U+W8UYZaRgsKylwVVMeXUVx+vpbT6q8suymFTNbOsdVNX0umj+VF2Orqazqh7N8k83/9zLgG/2fJtXVbyqRpflvKjvjy/mmD40XJf1+Ga03fiX8bS+t5Zab++mLOIi9cHxl3+NiyK/ae7Or+HiInnz8/mb9W3YuYFVPZ4tZh1XZdEEJ8055JPW2MWSTaQAIV+DfC3oHaohiCHpB5LyYtKaQkPmO49GXKOeV8ulmpTz8OfDIXHiJuDi7S9/BN+y8s4fe198LMovxeD3/Lb8nK/jx5/zWUw4+FwXk86rGPbAfY8R/77agwS8M55VooRLHLLOgFIZMkhM4hyrViT6iEi0tVYaQNqLhHuNBDe7P1DJNuH7MhGwYCJUByaLFB6ifYzJ29/CeQ+cbE/2CVBQOhdSQM02y7yKh+EBlPE2BQLwSSsUc0QoSpNURiu5F4rpNRRtuznZxJ+CCcvOTOCFVJPNuT4BiVEStMxQKxSUSOGN1UaSJ5eSdxm0IrFHRqIlPoLkR8v1bEik6IiEhvLRWtIPJM/RckFwIqB1REmIjyVSMCaWEhm08w7BtyFhOCISY+JONMN+JNRrJAhdWy44RcvF76BhAoczWabQTvnpN5PtwT6l42IvOAOJmbSMjjFxaWCdOq1TSrbvdfec4BGdWCHZmtgE7nUie+1Eq44dlzqhEjz8xWSthMQLeTHZHOwTlMTWxrMKHlOGQITKegpSoRLsLVDWqkQcUwlYMFZovVeJ6rUS1VGJOqUS0b2WCPMyaol6BiSJY4leGNZJmtiQkgIt0Mcj4YCcYSsSOh4ShfFDTER7kXCvkSBwNyXbhO/MhBsmuguTmMJDvPtw9JTJ9mCf4CQ+uKA1OsugfQZIiWAOWhiXxpYrbX814SM6AY6lxFrcX0x+tFzPpoSxoxIayrvd+P+55YrVAxMwwYBPnIm9Fhu2mfFkQ4Ja2VYl8ohKFtVE0gtvuWQ3JZv4kygx3ZXQCWrJfwAAAP//nFbJCoMwEL33K4oHb5pJTNQUpF9SJKZxQVxIYilC/70ubcVTS6+zP948Zv55udiPIjle5kCnVXeb9nPhQa8klNb25oTQGLQi83ICccQ9DjlQzCiAhPAacCqZIEpBFnGChT9O3ZSpvQlxUbWFL7sGib5CN4I2nOa88ZLKQZtOJziiMTAehLG7E+vb/02v7jK6qUaVYHBfu5Ts98gphUmbTi/MWj2oxfhJXC/w4fEEAAD//wMAiU89lK0gAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:13:59 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "727ac744d828fa7d1b11f4d602df9535"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748016150&engagement_id_cursor=1F93A4B40AA54D1371C74EEAC3A5FD78&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:00",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748059368&engagement_id_cursor=3601A08E80DAC85614849F8D39EA1769&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SXTW/bRhCG7/0Vgs8JsPOxs7u6LcllUKB1ijptDzkIgkU7QmwyFakERdD/3qWsD9cylRCyIulGaN7ZWc7y0Tv79afB4GJ8W5TNqChv48N9+zgZN+OLwXDwfvA1xqPiUWw6aSMXueROHOXB5zrnVEtumI2Jv4jTwfPFq4fMZnr9sVhlOWaWZeCh6MPvRgSBrBOyZJbx21k1//Q4DtYpR8ot47Pi73lRN8VsqbFihcA5ZVjTUlPd3MR4M70vRnVxXZWTulXyagd1Pb0tFy/VVKOb6axuRrPi090/Wxnqf3u+L+o6PtWj62peNtvxdo3pc+GmasZ3o83Gv4ynzVYtUKsO3FVlrNJ8f8L1h3FZFneL8/k1XF35Nz9fvlkdxKMjrJvxrF12XFflQuwXnSgmndq25kKJCvVrpV8jv1N2qHBI8ExSUU46U3gI9snHEWs08/qh1CLl7W/h8nlNXHmhuHr7y58h6yj96M3+KD+W1Zdy8HtxX30uVvrx52IWE76/s+2q8zrqnjn7qPj3VTcoibdW+8AmdQ4jGahCMIyMkmFwSneCYg4JCoNVHPezExR90qAY14+Ttf4YmLD0xmTr09jC5DL8dQKUrPu6BySaBcVn4MkCa+AUiS1nHBgTk6LphMQeEBK0rAS07IZEThoSkX6QrPXHgERTT0hoqN2ZeMm6sXtQgsoFl5P3LvG5T2zmfWp0rmz0lgyFOilxB6REK0OoLLqdlNBJUwIK+s5ccBROAFtOlOvBSZsSOVHnYSabxu7BicU0dxnkqc/QYmLZpUDB5AmZNLGEXZxodUBO2BJoI9/g5MRHLt0Pk7X+GJQg9qaEng4aJ0rJuq97QGIoDaK9Zpsbl2LQZG3QjgwoyVHSTkjgkJA4VCCyXuMsR66ekMhRIelvJcTnMnK9ACXIJhivBZRKbOp8ZhIgFe8lARBzbzspwQNSYohIAPicrST+y/QduY5zNQFZXE16cRJTeMj6PMxk09g9ONEpoXgLSbBpTi6w5gwCpSpzoK2FTk7okJwAUqzAsJMTc9Kc2J5uYo/kJtJaA+j+lJzJxcS+gJm4eCHJAPI4Y2WQJSZl5dM08Uoyb2QHJHxISNhgdBTUZwyJ9PQSOZ6V0BChNyR4JvcSeQEnIQUmE2y/aolzFltGm6CWHCR6iX/aiQ0k+oCQWKfJOfWNewmdNCSgelrJJuHHYoKqxUSrHpi0KXpIP37i+g8AAP//nFbJCsIwEL37FdJDb20maWoaofglUtKYLkgXklQk4L/bRS09KV5nf/NmmPnz4/r1mOzPk6HXqrvN+inyoBcWKmt7c0TIRa3Ig4JAwnjAoQCKYwog4XCJOJWxIEpBzjjBInRjNmWuwQi5rNsylF2DRF+jG0ErUHNaicnkoE2nU8xogjGDCPzNvr7131bWn0s3tVMpBv81TOl2kLxKmKzp9Eyt1YOahR/HpW27xxMAAP//AwCrMSnxsCAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:00 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "49d37c9ab8f1fefbc3ee696b3b70bbd4"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748059368&engagement_id_cursor=3601A08E80DAC85614849F8D39EA1769&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:01",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748117030&engagement_id_cursor=3017D62383764E448428B256F16D91A7&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SXTW/aQBCG7/0VKOdEmt3ZT25eezeq1KZSk7aHHpAFG4oCdopNoirqf+9iPktwFIsQQFxWzDsz61k/ntmnD63WWdr3WdnxWT8sRtNlLy3Ts1a79bP1FOxBsWYb9KaWM+sEkyCRoAaFNoqTyIJyBExiiUB+dj7zLAfdO7/w0oxxMTfMks7+l0JQgkoLVCjn9v44n9yv24nSoBH03D72vye+KP14rlEi/LQSBIjEuSa/vQ32cjDyncJ386xXTJXLHRTFoJ9VD1XmndvBuCg7Y38//PPMA/7b88gXRVgVnW4+ycrn9mmMwTZzmZfpsLPa+GM6KJ/lkovtDfMsJClfre/+SrPMD6vT+Wyvr6PLj1eXi2NYO8CiTMfTqGmRZ5U4qurge7XaacpKSYHyC+AXlN1QaANrg9ji5LNerQtvU7rxaoQc5aSYpapcruyP7ZIQuBJcf/n03SY1mdce7Ft2l+WPWeurH+UPfqFPH/w4OLy6rtOgkyLItpx7UPw9r4ckTjS6mBjpEppw65wRLkHBNEmMM07UQiL3CQmnVEtQ/IQhEQ0hEYeEhNDGkBB1GpCIN4DESEy0ECZSoQyWaeDMupgHbhKmjIFaSNT+IJEglCKC8pc7CR41JKETNqNk5fCemPAbCO88bVP2akxmLqH9bI4ZR4rJqrA7cBIJrmwEaGjMtVaMU24jB5JRIy3HqJYTvU9OCBNUMSlf5OS4m4lkDScudkBKUDekBNscT4OSZV13gERKq2MVXkpDIbLKxZZr5QIviC4MYbIOEgH7hCQEkJzoU4ZE8GaQLPWHgIQ1bSXYZvo0IFnWdQdIXAJKxWi4dsAjQyLKrDXaxYJBopPNSqwgIXuEBIEiEsFevpYc+8SFzShZObwzJmyKCTTChFWYbH5BjxSTVWF34SQ2MbcYQyyBB0yEDFeCJMw7YewCamwtJ3TPnDAlT7qZyIbNRB6omVSUkEYTV0UJstOgRL5BM+HWCEUt4ZSCwYhDHDkBEQlDjwSLqhYS3CckhIYIq2vXdkj4+0PyDwAA///U10tPg0AQAOC7v8L0wK1ldvYFJo2Bbjmqf8A0FOkjpoXwMIbE/+5CFdJDJZumtlxhFtjZ/ZhZk45LmCFp46+BBM1LCYU+JM8v86cbUNIm9hwlXLmccIYAXiCpp3QJoVQITwKCUuqkEnZBJQwpMmQu/VPJrbdchrWkG/DPTpym5eImTpzaCR+Kky6z5/RcwNDjBGa63fKU7xIBPvgoqWRqHsyCk1D4JaEICg7owCH3XNLMSRt/DSYIxkzoQE4mbV77kNy/1oGjffxZLNL6wWV2WIRNUaT5g21XdB8uxysEfRoYu7ACpgsMQATijbos4iHGMSyliyScVPptcf4+1jNeb/frSZTs7DDd2h9od/PMH7t1WURllifZlEjmaIOEgXWE9fd+n1er+fR8W8VTAtbPXpoe76PRJswXuyRrVrbIyri52A48/Fvuvr4BAAD//wMA7LWuPKwgAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:01 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "4c47017da0847daa6c65a68426349627"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748117030&engagement_id_cursor=3017D62383764E448428B256F16D91A7&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:01",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748160140&engagement_id_cursor=F042A510C1A6ADB9160B0B27374DEFCF&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXS2/jNhAA4Ht/hZHzLkAOyRnSN/G1KNBmi6aPQw+GECupsYm0teRdFIv+91KKI6dJ5F3BVWLfBM8MKY30meSX72azs/y6KJtFUV6ni9v2cpk3+dlsPvtj9iXFU8aD2GrZRs4YCC04GB+AmM8Y08oiF5EJjhlDf/bmrrJZXX4o7quMlIjbwN2kd78TInChDaYxaRu/Xlebjw/jXBtmBDPb+Lr4a1PUTbHe5mjUpASXKIwQ25zq6irFm9VtsaiLy6pc1m1mfwd1vbouu4dqqsXVal03i3Xx8ebvJxXsP/d8W9R1uqoXl9WmbJ7G2zFWz4WbqslvFrsb/5yvmqd3d9+Am6pMkzTfnH/5Z16WxU33dn4MFxfZu+/P392/hgcvsG7ydTtqXldll5x1fSiWg7ntlF0mMFBvmXoL6hem5wzmgM8UFeVysETMhXj0aaQ5mk19N1VXch5+fz4lDdwlXLz/4bfgB2Z+8GC/lh/K6nM5+7m4rT4V9/n5p2KdCr65r+2gmzqlPfPeU8Y/b4aRUIiaLM8yMFxhpExFS1F6IqM1cDOIhCZEggZRCqn2I5FHjcTocUj6/JdFwqFFwsQIJG2JmEt+Gkj6vh6CJKJHDIJpcKQhw8wSU8Kmz9RasI87sUOip0SCnKRBMHuRqKNGQnIckj7/NZBwNRoJPP7/PFIkfV8PQCIVWCV1UDpIlUUbpDDAyBvCGCTBIBIzJRKTRlHK0AkjQTUOSZ//GkiAjUeivobk/U/h/AiU9I09QAkyFzPjgHnp0smEJyJoWHQYHDjPB5cSYhMqMYyjShs+fsL7Lc5wHJNdwQs7we6jhzFOUomaM30ai8musYesJl5kVksrkIA5JwWFQEo6a4MLzrtBJ3xKJxwlKiX2n0vwqJ0QjWPS57+GEkEjlci5kieymvSNPUCJ5xIj4yY6L6VlYCJaHUkwD+lrFXFQCUytxAjar4SOWsmp7Lk6JVKOViK/ejA5EiX/x54LOARuY+QBwDptdAbEotWgrfeQDSsR0ynRjBTXWuNJ77k4H8dkV/CyToC1ZxM1ZjVpS5KTU9lz9Y09wIkOmROQziGcrJFGKoYOvI/Bkg+O20EnckInnDEljOK018lxryZkxjHp86dU8i8AAAD//9SX22rCQBCG7/sUxYvcxZ2dPcQVQhFj3qKENV01FJOwm4gE+u5dY1sRKhpKab3dw+wO/3zM/N+XPJtSMZgSdjczl/o5JTwFhnJBGUvZLOLRQgpIIOFzOgGZJvIiJeIXKfHdBH0Idc+UyIHORP6NMzlSgjiYErw6c/2PXiJvNSaPz4eDo9Lsm6w+BG7tUYRN09RuSkjHSr0MVwjeFIQKVsCp4AA5yBemeC40GgPLSCHV486/Ztxr6DNeF+V6nFdbouuC7JCc8nRPJ12yvLWusjGN+ASBccDgDNbP/Wu8Bv3XXdGZmELwUUvxeR2NNtpl28r2yja2Nf3i18W+A8PD2zsAAAD//wMAmj2QrqsgAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:01 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "07d56631c19c956dc94b74bb6fa752b1"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748160140&engagement_id_cursor=F042A510C1A6ADB9160B0B27374DEFCF&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:02",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748203402&engagement_id_cursor=4F0326E133F3A747E650D0D4C1806FD6&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXX2/bNhAA8Pd9CiPPLXB35PGP3yRSKgasabF028MeDCNWMqOJ1Fpyi6LYdx8l23KWRE4Ex7GcJyW8IyVKv/Du5y+j0dn0OsurSZZfh4vb+nI2raZno/Ho79HPMB4i7ozNZ/XImYqNAh/5VAlWkWZMTSLAU2pTYCZ/9maVWc0vP2ebLCulVuuB1aKrv2ulCIWxShih1+PXi2L55e44GgtWgF2PL7Kvy6ysssU6xihjSLE0lvRmjuLqKoxX89tsUmaXRT4r60ixuYOynF/nzUNVxeRqviirySL7cvPjQQb8755vs7IMV+Xksljm1cPxeo75Y8NVUU1vJtsb/z6dVw/WQsB1+E2Rh1Wq5ydc/jPN8+ymeT/vk4uL6N2v5+82L+LOKyyr6aKedloWeRMcNTuRzTpj6zWbSALit8BvSX0CGAONwTySlOWzzhQxlvbexxHWqJblaqkm5cPH5PzxmDBzE3Hx4bc/E9+x9J0n+yP/nBff89Hv2W3xLdvET79li5Dw/J2tZ12WIe6Rdx8i/n3TDcWl2glQiDYWTiA662MEA1oHOYFKJxR9QCiCpEXL0u6EwoOGomU/J238MZgQ9WYi1FNMzpO/BqCk3dc9kLBWqcGEZMreBSU2/I7hK40lyUi5+zuxRWIOeZoIq4E18QkjUdwPSRt/FCS6PxI6DSTtvu6BJFRZSsaxjhWDhih8m+RZOkAm4RIrOpHYAyKRyqLUKMROJHLQSBCpZ8nVJrwyE9kw4T5MQoocoz4NJtuN3cNJABJ+UMRxXXoRem0jqcgLLyDFNOpyYuCQTiRZK5l3tyZq0E5Mz87EHKkxaZTIXhVXowTu/wsdamNiXqAvsWkgQkkkfCi60HnJznhpo1QDePayUwkeUkk4TTQ/1ZeYQStRup+SNv4YShh6KhFjfvIsGYiSdmP3UBJODFaJtsgWQaQycaAVJSJhy7HyrlMJHVBJqPyYgGG3kqHXXD07k23CKzsx9UeP2MdJSOEx3O9aB1tzvUBvwmSaAkeCcQIduAQMWorRSBEnadzpRBzYiRDiCSfDPk3aovS5NRccUYnoVXOZuuZiOg0l7b7ugQRC/R8qK0RNjCqxGJNLRKyTWCVebR/hARJ5YCSShN3dmAwbyamUXCsktjcSeSJHyYtUXBEgGGAlpUOtVSycVd6gjxw5p7ETCR8QiSUiBNRiJxIeNBJE2U/JNuF1mSDVnYnsw6ROCUzEq3cm/wEAAP//nFdLCoMwEN33FMWFO80kRm0K0pMUiWn8IBpJYilC715NP+Kqpdv5z7x5MPPvyUV/JMr+vBh6vbzZfFgij/oJQ23tYI4ITVHPi6AkcEhZwKAEimMKICC5RIyKmBMpoUgZwTyc5mzStMHcctX0VShUh/jQoCtBa6PmtCKTi1EbpTOczg9NAixh/oawb/03zvqudNNMMsPgv7Yp226SV3OTd0o7bK0epRN+HN3YYHd/AAAA//8DAMKv5YSxIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:02 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "b6d352bf64bedd31ab23b12ec2e66cc4"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748203402&engagement_id_cursor=4F0326E133F3A747E650D0D4C1806FD6&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:02",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748260969&engagement_id_cursor=3A010805644C1776B3C96D81DAC2CC71&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+TXX2/bNhAA8Pd9CiPPLUDyjryj3ySSKgZsSbF020MfDCNWMqOJ1Flyi6HYdx8t/8sSy4ngOlbQJwu+O5Gm9POR334aDM7GN3lRj/LiJl7cLS4n43p8NhgOPg6+xXjMuBebThaRMxbBey8yw9IAOalQ2dQLsg6zVEs4e7OsrKdXn/J1lUVkswosB11+T8YoCWwNMNAqfjMr55/vxyVbYUHYVXyW/z3PqzqfrXLYcExgDaBQr3LK6+sYr6d3+ajKr8piUjWZ6xlU1fSmaH5UXY6up7OqHs3yz7f/PKoQ/5vzXV5V8aoaXZXzon4cX9xjuitcl/X4drSd+NfxtH48u3X2bVnEQepn51/9NS6K/LZ5Or+Gy8vk3c/n79aP4d4DrOrxbHHXcVUWTXLSrEM+ac1dDNlkKqH0W6HfKvNBqqGAobA7ivJi0lqCQ2UfvBpxjHpeLYdqSi7eh/PdOfHOTcblxS9/BN8y9L1f9nvxqSi/FoPf8rvyS77OH3/JZ7Hg2Qu7uOm8imk7HnzM+PdNuxKniB0L5ixJ0CqZQgAjpURtIEoJrUromEoQlTFgXrMSQ92UbPJPoUSa7koe/oE+UnIe/uwBks26HoBEOrYBgvbOQJJppyBLTGoVp4rApw//L7ZI+HhILMSbSGaivUig10ik4G5KtgUvy0SJoVBDxA5MFiU4BPU6mGwX9gAngkxwnqw3iIlxLjJhJySpJO6+gnOtTuwRnaCQRoJ+oplQr52Q7cZkk//ySuKWS3RWIp/ccvVDyWZdD0CitAXn0hCIhM5CwPiZMiUCPaUuwTYkVhwRCQBJTUCwF0nPd1ymG5JN/kmQcHckD1+NniLZrOsBSEB7zJREY1LNkDrwoKxgpCx4EbxvRSKPiETHcxGx3OTsRqJ7jUQK3U3JtuAlmdAH0ey4lHw2k2UJDoV5HUy2C3uAE+2cVVJrhSZLExARiSOTGYcppZkMrU7UMZ0ohXFSQu51YnrthDo2EzpFM1krAeqoBIYanlJy8T6c94AJfYdu4hKHwStO4pvtAmuIJxSborMkmL1uPZdYOKaSOA02Fvcr6fe5xHRsJuaUvQSxsxJ88lzSEyXmO/QS4ZWKLhLETHrLqZcaZJLYTKQ+CEutSvCISlhL0mTs/oMJ9FrJ69lz4cKJ7NRNsNlzqR9ozyUgvpBZxgaNwBQMO+EyH8gb9qSTdif6mE5k3NMx8P5u0u+zCVE3Jpv8UyiBTicTbLoJn0DJfwAAAP//nFfJCsIwEL37FdJDbm0mbWJaIfglUtKYLkgXklSk4L/bRS09KV5nH968Yeafk4v/SJL9eTL0Gn13aTcF7s0CQulcZ48YD1EjMz8PIeaJn0AOlDAKoOBwiRKqmAy1hoyPL4wMhjGbtld/7LiomiJQbY1lV+FbiNc+7WnFJVW9sa0RhNM4IjFjBG3I+tZ/4yuaS7fVoAUB9JolsZ0jr5Q2rVszI+tMr2fhx3HZLbvHEwAA//8DAFFTP76tIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:02 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "12aebb92b4ad4c85e4545494ba7075d3"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748260969&engagement_id_cursor=3A010805644C1776B3C96D81DAC2CC71&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:03",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748318551&engagement_id_cursor=03576FF864604B368C0CFDE7D68D75A7&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXX2/bNhAA8Pd9CiPPLUAeybuj3yiRKgZs6bDsz8MeDCFWMqOJ1Flyi6HYdx+lxHHaWGmERLEFGIbguyNlyj/z+OWH2ewkvyzKZlGUl/Hiur1c5k1+MpvP/pp9ifGYcS+2WraREyEwQxKETljhyTrSmSYkBcJx8PrkzU1lszr/UGyrrNYWbwM3k958ToggFVtUrOg2frmuNh/vxyVbYZWwt/F18c+mqJtifZvDyJYskGVB2zGqi4sYb1bXxaIuzqtyWXejbe+grleXZfelmmpxsVrXzWJdfLz690GF+Oqer4u6jlf14rzalM3DeDvGal+4qZr8arG78c/5qnkwF24X6Koq4yTNk/PP/87Lsrjqns7P4ezMvfvx9N32Mdx7gHWTr9tR87oqu2TXrUOx7M1tp+wyQYB5K8xboN+EnguYK95TVJTL3hI119/+NOIczaa+maoref9LON2fE0fuMs7e//RH8D1T3/tmv5cfyupzOfu1uK4+Fdv8/FOxjgVPXth20E0d0/Y8+Jjx35t+JcyorUmt0ywkQRayTLEMzgmmhAP1KqHRlFghpUbLpO2jStRRK5FiIJNdwSs74daJxCFOYkmrayJOdiv7DCgqw1RJUhqYfZaI4OJvWKWQagOSbNoLhceEEhO0lfLx7QSPGgoNdEKHZKJgIJO4nfD3mJyGP49ACb0AkjT1MgkucToDDZim0oBKYt+VpMyAoheJHRGJsGhJszYTRjKVnouH91z8tJ7rOJC8RMulbaoCJBKzAD74NHhSXnKSmUAiCX07iRFiRCRABsAKox5FcuQtl+JhSnYFr8tEQsdEDWDSlui5kVNpue5W9hlQgkJA8oI4vkvH1ijrSQdAZzMP2AtFjghFgYx91y5nPxQpj1vK3X/Jkw8n4mBSVHwNlqLVVKTcrexzDidABGzZSCNBGx0spVYrZm0T7Rz1SoExpcRzCbExjx9OjlwKDYRCh3QizWAnYCbihF6ACQROM5LoyGdCBcp8ikF4r3TiZQDXy0SNyMQojANEK1PuvPTA88mu4JWdYNd5wRAn2HVePBEnu5V9BhSDIsHEJUIkliyz90IGTIX2iQRF0AtFjwzFqF1317OfwFFLsQOPKPZAJxTs+i4c7ETriTixL3BASTIEJw3bTAkdgk9T9pmhgGhkVBJ6mZgRmeh4SkIF+B0m4qiZkBzG5C7/EEwkDWYCr7ad/A8AAP//pFbJCoMwFLz3K4oHb5qXGI0pSL+kSEzjgriQxFKE/ntd2oqnFnp9+zAz8P59u/CPNjle5kKnVXeb9vPgQa8slNb25oTQGLQi83ICMeMehxwoDimAhOgacCpDQZSCjHGChT9O25SpvQlxUbWFL7sGib5CN4I2nOa8EZPKQZtOJ5jROIgw48zd2fWd/+ZYdzndVKNKMLgvMSV7ITmlMGnT6YVaqwe1BD+Nq7sOjycAAAD//wMASGQImLkgAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:03 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "16"
+          ],
+          "x-request-id": [
+            "ae679550d4c957ebb0992aea6524b210"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748318551&engagement_id_cursor=03576FF864604B368C0CFDE7D68D75A7&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:04",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748361797&engagement_id_cursor=BF62A1589F304EEDCC8DF57E6651372E&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SXTW/bRhCG7/kVgg8+xfHO7MfsCjAKkrsMCrROUafNoSgERqJlwRbpkpTTOsh/L0VJlL8omVAUSScRnHd2ljP7aGa/vul0jqJhnBS9OBmWD+Pp4yAqoqNOt/NX52tpLxUPbKPB1HKEaENryWoWeAZRgU+B4owTBoZJw4/ezjyLUf86XngZIZmaG2ZBZ+9JKQSujeKa09w+zNLJ7UM7aMMMZ2Zuz+J/JnFexNlco5VhxJErgVrONenlZWkvRuO4l8f9NBnkU6VY7CDPR8Ok+qgi7V2OsrzoZfHtzX/PPNijPY/jPC+f8l4/nSTFc/t0jdFL5iItopvecuNfolHxLBawxf5u0qSMUrzeoX8VJUl8U9XnV3dx4b3/+fz9ohAPSpgXUTZdNsrTpBJ7VSbiQaN2GnNWdobyhMkTpI/Iugy7IF5wipNBowvvSv3kcJQxikk+C1W5nLtPL0vKhSvBxYdf/nS2IfKDD/sjuU7SL0nn93ic3sULfXQXZ6XD6xM7XXWSl7oXSl8qvr1t5oT5KDhKlC4kLows0UCPiSAw4IdSNHNC2+QEQUlDxFdyIveaE6J2mNT6XVCCujUlQq6j5MNv7nwPMKkTuwElSMw5wEADlL+KpG8DIBAhIPeMxkZK9DYpIW1ICzQrKVF7TYlS7Sip9bughLfvJYIdCCV1YjegxAYWmEQTKhMaJ7R2GEgrA2GC0C8PdCMlZouUGK6JgRGrKdnvXgIALWeu2uFHcqI/stnMZV7NycxFdGEtJ3syc9WJ3YATCnyurJKcyKEgrkPpOyTLWOjA8MaZC9iWOUFc101orzkh0w6TWr8LSji1pKS8magD6SZ1YjegJPQCACGNc1KEUjqrfOMMSe3IhuTbRkpgm5QYURaFUB4wJarlzUTt4mayoES8fuaqKYEDoUR9h5uJ89H61pO+sug78AwLJFjnFPdCj3zdSAlujxIAVCgNsdW9ROw1JQC87czFd8OJqGYu2YYTMZ252NPDsa+cLDO7ASgeg/KiYYPQQ+YpzoGF3HlGCxC+o+Dpf8YSFL5FUEoREgpxyO1Ei3ac1PpdYMKhJSZlO5EHgkmd2A0oMZo8jyQHy3z0jOO+lkoFLrCStHZeIyVii5QAF2AMqNWULDvaXmJyKFNXhYng7TFh6zA5d5/2gJLvMXTJUGmyYDCkafcIHbnQ5ywgcBBaEI2UyC1Swg0yZbReTcm+D13YjpKlww/GRFdDF7XBRFdDlzkMTJaJXcdJ5++p8CiJ/y16t9OVJ9msCldFcZt3T0/veRJ9PrlEpsmcGHbJBEjBWJ+pATeiLyOMY/aZDEL07r6MFufXJ+UnD0fJ8F0/HZ9Gt6PTOzxdfmj+07Iwvf4ky9PsDEiUo5zhnI4f8bqwr0P2uNp6PrqPz4Adzw/T2eODdHQV5b1xmlWlLbJJXL2sHau0sTff/gcAAP//AwBJb6uWtCAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:04 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "12"
+          ],
+          "x-request-id": [
+            "3e27b9fb1617b92301a4fca5bbb38691"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748361797&engagement_id_cursor=BF62A1589F304EEDCC8DF57E6651372E&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:04",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748419337&engagement_id_cursor=5F687D192F714BEFE7EFB30C71E1FD14&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+SXS2/bRhDH7/kUgg4+xfHszj4FGMWSXAYFWqeo0+ZQFAIjrWXBFumSlJM6yHfvknr5RcuErUhCLxLB+c/Mvn6c2W9vOp1uMnJp2XfpyD9MqsdhUibdTq/zV+ebt3vFLdt4WFm6GAvLWWypUoEFidpIHdlIYEiCCFXQfTvzLMeDC7fw0owTMTfMks7eSyEoQaUFKpRz+yjPple37URp0Ah6bs/dP1NXlC6fa5TQBDmTWiNfxMjOzry9HE9cv3CDLB0WtXIxgqIYj9J6UmXWPxvnRdnP3dXlvw884M6YJ64o/FPRH2TTtHxor2KMHzOXWZlc9lcD/5KMy4ejI3P1ZZb6JOWz9YPzJE3dZb07v9rTU/P+55P3i224tYFFmeRV1KTI0lps6nVww0ZtlbJWUqD8EPghVR9B9YD2kD/i5NJhowv2uLh3NHyOclrMUtUuJ/bT4xIfuBacfvjlTxs1ZL41sT/SizT7knZ+d5Ps2i30ybXLvcOz17UKOi287JF994rvb5shMSZiQawDY4OIMB3pOOTE0wKUAKI1jZDIDUJCJYIPgfgkJAR2mhIh21Gy1G+DEsbaU0LWUfLhN3uyA5gsF/YFmPhSYhinIQ2lUSIkNmTKkjDm0v+IkDViojaICWegpGaKP4kJ22lKyJLiZ2KycvixnBBacUJ0C04qF9YDvSecrFb2BaBIZRAki8MoFBYjHvlzajwusQpC6mtNIyh6o6AIiYrIp+uJ3GlQpG7HyVK/DUxQtsTkOU3XjmCyXNgXUBKFhAprQ45CxqFkhiAKyhkLGQgbYRMlFDZJiS8mUiIje0zJnjRdM0paNV1zSv5PTVfAlYgCsGADjf5RBxArRYwVjJgQminhG6RE+eTAfagnKeE7TYlsSYncDiUUqiMPtAUllQu71aXtOCXyFSgxSCw3zF9NwH/BUVgRCESITCBkKOn9srqiZINXEwqMUcI17nPHpVreTNQ2Lib6I9RHvgUlMxfeo3QdJSf20w5Aol7jWsLQl4zYN1o0igmniDqIQmaEYSRWOm6EZIPXEr8hQJnmWj4JidppSPai4VpAQqA1JETuSSl5jYbLxMYf+YBakBJkYCiGovq3TCvFYtNECW7wWkKp4qDlOkpwpykhhLXDZOXwgzmpKkmPqzacsAotvifFZLWwL+CExzKIue+wFGGChiEHwuPYN17EEoP0fve54oRskhMuEHxh2+uWi7ZsuejWKMEeEa0pQbUflCzXdR0knb8rYTd1X8v+VRV4ms824bwsr4re0dENpsnnwzMKSupDDWfACGcAAxBD1GzAE+ocfJaakuTdjc/miotDP+PROB29G2STo+RqfHRNj1bzLH5a7Ut/MM2LLD8mkimmCWpxcAfWhX0drwf10IvxjTsmcDA/S8d3z1H3PCn6kyyvd7bMp65+uXSsvy3w5vt/AAAA//8DAK0bn9yuIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:04 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "7dff4d8246c8649927266e0bdead028f"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748419337&engagement_id_cursor=5F687D192F714BEFE7EFB30C71E1FD14&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:05",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748491396&engagement_id_cursor=5F7BF5DAB81462CC5015FFE6B1E1A329&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+yXTW/bOBCG7/srjJxbYIYcfvkmUWRRoJsWm+7uoQdDiJWs0UTqWnKLotj/vpT8oawTOREcJUqxJwued0iK5KN35scvk8lJepnl1SzLL8PDdf04T6v0ZDKdfJr8CPGguBFbzOvIiZVCe8GEYokjYzGykbDGeS2MlM76k1frzGpx/jnbZhkSnG0C60nX/yspGXJtJNdcbeKXy2L15WYctQHDwWziy+zvVVZW2XKj0dIwRsAVAImNpri4CPFqcZ3Nyuy8yOdlo9yuoCwXl3nzUlUxu1gsy2q2zL5cfb+VAf9Z83VWluGpnJ0Xq7y6Ha/HWNwVrooqvZq1C/+WLqpbc8nt8q6KPExSPVh//lea59lVczq/urOz6M3b0zfbY7hxgGWVLutR07LIG3HU7EM279TWUzZKBky8BvGamY9AU+BTRnckZfm8M4WmnO1djTBHtSrXUzUpp+7PuyVh4EZw9v7dHy7pmPnGi/2ef86Lb/nkt+y6+Jpt9enXbBkSHryv9aCrMsjuOPeg+OdVNySxNTFChBBLQZGUMXfO+ERHQvM4bjfvFiQ0HCQcAZmCgO5BSPioIcHdGz6QkjbhaTFB1mAie2BSp4gpipeBSbuxR3BCRjFALpmSsXWgpFZkkshFGrW3Pu7kRAzICSiNAonhQU7kqDlRsh8mO/1zUEL9KYF7zeT9B3c6Akx2G3sEJeFCu0gRgATJE6cgQSmV87ElaSAynZSoASkhzkPRFQZ60W7SE5M24Yk5keHGT5H34UTWaIn9yzFaN3kETlyorZRVwTi8w1BzaTCWIsUM84kyCjs50UNywgAQyPCDnIzcTVQ/THb656CEmd6UtAY0djdRx1OCDEhpHUovqxMWTCSYCUbcag/OWh51UUIwICWKS6V4+DlIiRg1JQisr5uwZ+GEQeMmrAcndUpwk/3GdayctDt7BChJsBDhPAglRH2PY40eUWrPIy8TDZ2g4JCgIIXeROOLthPRj5Od/jkwYX2akzUmtF9pjLTo2u3rEZAwrbhj4BLBGBrGDYJOvI0lITkHvBMSPhwkBCQAOaI6CAmNGhKEnpS0CU+ICYeP0Nx5oIdiskmhKd3bm4zGTR4BFMdJKyV4rHRkWfiGW2fQmNh7YUAl3WUXDQgKhu4kWMo9oPzvJo+GCcPemPB7m5Ofx02MJZc4tA61D4WW45EliqU3SZxwkvsfjBYSOSAkJIUKZZ/Eg5CM3U1eQm9S33mqiy7QfTChpjfZr8eHxeRfAAAA//+8V8kOgjAQvfsVhgM36LQU25oQv8SQUssSwpK2GEPiv8uiEk7evM7+5r05zB9ek+N1DvRa/XBpP1cezMpC6VxvzwiNUSuzICfAmQgE5EBxTAEUnG6RoCqWRGvImCBYhuPUTds6mCAXVVuEqmuQ7Ct0J2gDai8bMakajO1MghnlMWOMcH93rx//r5P1l9FtNeoEg/8WU7IXkldKmzadWah1ZtCL8Zu4ru3wfAEAAP//AwAYa9RjtCAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:05 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "14"
+          ],
+          "x-request-id": [
+            "02ae45e23cee71102290005f3957f69f"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748491396&engagement_id_cursor=5F7BF5DAB81462CC5015FFE6B1E1A329&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:05",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748577728&engagement_id_cursor=9C4EDE1CE18F68FE3AC44B6F9DBD3469&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SX227bRhCG7/MUgi58FcWzh9ndEWAUy1NQoHWK2m0vikJgJFoWYpEuSTmpg7x7V9TJJ8ombNnUhQBC888u9/Dxn/n+rtPpxuMkLQdJOnYP0/njKC7jbqff+bvz3cWd4kZsMppHulwgA23Iagpt4PmeNgbBV6AtGR6y7vtFZjkZfklWWSRR6mVgMenif60UZ8KQEkas4uM8m13ejDNDQAJoGc+Tf2dJUSb5UmMUSSkRyRiJS012dubi5WSaDIpkmKWjYq5cReOimIzTalFlNjib5EU5yJPLi//uZcCtd54mReGeisEwm6Xl/fh8jMlD4TIr44vB5sW/xpPy3lxaLdUXWeomKZ+sH57HaZpcVKfza3hyYj/+fPxxdQw3DrAo43w+alxkaSW21T4ko1rtfMrFoQPHHmBPwCnIPvA+Zw8kJemoNkX0hb5zNdwc5axYTFWlfPotPH5Y40auFCeffvkzDGqmvrGyP9IvafY17fyeTLOrZKWPr5LcJTx5Y+eDzgone+DgneLH+3pKkFsg5WmUaMDjPOTKhtrzo8DXIZNUS4nZJSVIRIqb7ZSoVlOiGlKi3pQS3ZwSsSeUqBegxChL5CsJGiKrA/R9jegrZRV6bmNsHSVrQndAiZJSC8Ulp62UtNtLGMNmmGwSXpMTdsqh4oQ/mZNFiuyzR93kOPyrBZhsNvYZnHgU2SBQMhSBNCqIBCk0goch51oYLms52WHNpSS6SpD4I5zoVnNiRDNM1vq3oERCY0pgX9xkvbHPoCQQyvoy8LggJoUX+qFFCMk6QKy777U1l95hzVVRwpE/0pkwaDUmSjfDZK1/C0ywKSaij/vSmqw39hmYMOPZQHraZ4EOQzQIEUYkAUkYK5WqxYR2iAkiaNQIbCsmvNWUMGhadMGrF12qB+wUoElzsk5xRRffk6ILXqDo8oV0jiIi0spa9wWPpKvC3I8JIUkwrOPEwE45cd5miG+3k3Y3J7qhm+hXd5MblMgntibrFOcmdyuNllKiX8BMIKh6AF94UUSgAqsDQ9pDFRkuQubXQsJ2DAmiq7z2uDNRDb1EvaWVSGoOyd2mtaWQqBdwEkYYChVx46P0iHschZKaglAjYWDuFp8bSPgOIdGMyKCE7U4iWw0Jg4ZWskl4ZUzkHBPBmmAiq4rL7ElnstnZZ4BCPFA+MyExJnhI0qC1gpHxlZXg3KUWFLFLUOYKBoq2gqJaDYo2DUsu84aYyEaNSYUJ3K3GW+om6319DJLOP3NhN02+lYPL+cCzfHEI52V5WfQPD69FGn/unXEwmnoEZyCZ+5jDENRIkBxizJMEPmviLP5w7WZLii89t+LxJB1/GGbTw/hycnjFDzfrLH7anMtgOMuLLD9iWhqNgEof3IJ1FX+M14Pq1YvJdXLE4GB5l45u36PueVwMpllenWyZz5Lqz3Xi4tvy7sf/AAAA//8DABpG5y6wIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:05 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "082be800c065f1bd19b86f60a9705cd1"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748577728&engagement_id_cursor=9C4EDE1CE18F68FE3AC44B6F9DBD3469&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:06",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748750567&engagement_id_cursor=92D6C18E91132E9485AA3198C6A4006D&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXy27bOBQG4P08hZF1CxzeDknveC0KdNJiMpdFF4YQKxmjidSx5BZFMe8+lONIaWIlFTxKZMALOec/pEz5M5nvv8xmJ9llXtSLvLhMF9fN5TKrs5PZfPZx9j3VU+JObbVsKieCCEIp04DWEWOossFT6Xl6x72l4uTVTWe9Ov+U33ZpLhTfFW4mvfm7RKSEKY1MMbmrX67Lzee7daI0aAZ6V1/n/2zyqs7Xu4xCjZIryhUg2WXKi4tUr1fX+aLKz8tiWW2Tt3dQVavLYvuh6nJxsVpX9WKdf7769qADfrjn67yq0lW1OC83Rf2w3oyx2leuyzq7WnQ3/jVb1Q/mQrFLX5VFmqT+6fz531lR5Ffbp/NrODszb96evrl9DHceYFVn62bUrCqLbdhs1yFf9mabKbdJClS8BnwN5Hfgc6BzIfY05cWytyW94N5XI81Rb6qbqbYtp+Gv/ZE08DZw9v7dn8H3zHzng/1RfCrKr8Xst/y6/JLf5rMv+To1/PS6NoNuqhTb89xT4t9X/Ui4FFLaQINDr2mkERwaJjQnnkUSaC8SMSISpRiXFNsx9iPhk0ZCCB2mpGt4ZiaqYQJqCBN1TEy6hT3EiVFKkuitEzEgaE+ZJ5JrJdGh5rrXCY7pRANhyMjjTuSknSgyjEmbfwkldNBmklrYnONxKGnX9QAkTjtDg+UEReBUORMARPACLPFOyPsr0SGRYyJBKYjiT5y4po0E1TAkbf4lkDA6HMmRbCXtuh6CBIEHG6IjNGKMFixTITgZ0SgrQuxFosZDIoGkQxfI9kS5HwmbNBICbJiSruF5mRDaMCFD9pKmhc2FOg4m3cIe4EQag8xxp6jVhhOqiQdKvEZA7ZkmvU70iE4IpH6aUo86wUk7kWIYkzb/EkoYDFbCxVNK3n8IpxNg0i7sAUqiYo5wbgJ67omKRHDLNLAQTXAUXJ8SDSMqaXYTncKPH7mmrQQHKsEXVYLDldz/AZ3oXoL/AxJvLItCx+hcejllKPNCGm9lsFTH3q1EkxGREGyksCeOXHzSSAjgMCVdwzMzwYaJ4EOYpBZ+NP+ZdAt7gBPlovTgnAzGGioYs5FJGQIHxkCE+0vROaFjOpEKID2Woz5yyWFM2vyISv4DAAD//9SX20rDQBCG730K6UXu0p2dPXUDQWxJ3kLCNm7bIE3CbiIS8N1NE23pRdUgor3dw+zO4eOfuVDyLAI9mRKU10HJMa4/gGSpxb1IaIKQrrRYcdWPJylLlhQZplwlFyFhvwmJYKjZAj/vuNS/hkRO1BL5d1LCIjqp4xohweuARH5XSW4fDgdnpX1psvpguHVjEnZNU/uIkI6VZh1uEBZKhxo2wPvxBCAH+cg0z4VBa2GtNFIz7/rXrH8Ke4+3Rbmd59WemLogz0hOfvq7U16yvHW+cjFVvDfPlJbBGawf+1/xGgxf90VnYwrBey3F53U02xmf7Ss3ZLZxrR0WjxdHAb55fQMAAP//AwBmW6gKqyAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:06 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "2ec85e6923502f1735ccf65ae9cc7659"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748750567&engagement_id_cursor=92D6C18E91132E9485AA3198C6A4006D&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:06",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748793796&engagement_id_cursor=B95A5E1E20FC95C47B9AF3EB1232F47E&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SX32/bNhDH3/tXGH7IU9McyeMvA8FASlQxYEuHpdsehsFQbcYxGkuZJKddiv7vo+Vf+aU4QuLGfiN03+ORR350x29vOp1uOvJZ1ffZKAwms+EwrdJup9f5u/Mt2IPihm08nFm6aJmiCaJjwlDGubUWIkW4SiLHtXPdt3PPajz47JdeGrnGhWEedP5dCkEJU1owxeTCPiry6eVNO1EaNAO9sBf+36kvK18sNEpoSQUHLgjlC01+dhbs1Xji+6Uf5NmwnCnZcgVlOR5l9aaqvH82LsqqX/jLi//uecCtNU98WYZR2R/k06y6b5/NMX7IXOVVetFfL/xLOq7uxSKwlF/kWYhSPd1hcJ5mmb+oz+dXd3pq3v988n55EDeOsKzSYjZtWuZZLTZ1JvywUTuLWSspUH4I4hDIRwo9oD0gDzj5bNjownpI7lyOEKOalvNQtcuH39zJw5owc604/fDLny5uCH1jZ39kn7P8S9b53U/yK7/Up1e+CA5Pz+xs1mkZdA+cfVB8f9sMirNJYmIlREwTRaxl0jJ0ziKNQBrJG0HhWwSFESkBBDwOCt9pUCS242Slfw1MCLbGhKpNmJy4v3aAklVenwEJR0mciawwJiKcYLih4WcupANlYmB3M7GGRGwZEoKcyz2GRPB2kKz0rwKJbg8J7kktWSX2OaUkFk44EwdMEEVinUJGrHBIiKCCskZK5BYpwRAYhEbyKCW405QQoG17LvoKnNCPMO+5ns7J3IX1+MaeazeKyTqxz+BEKEVY5IBLK7W2CBqpluAixpkRJGrkRG2TE5RS8TDVHlcTKdphstK/BiWUtqbkXqOxq9VkldjnUCJC8SBGaHCMyTiBSHDDEq7iOEbtmnsuvU1KKAmQ4AZKxE5Tshc914oS1Z6Su43GrlLyMj2XdlYRS42OrSYmlBIau0hbR5xD5RooEQBbpCSgq6gm5PGXCdtpSghgO0zWDj+YE6zfJqQNJ1j3XHxfei58PidokCRS8Ai1iQxNQDmC2ipAaixNaCMnZIuccE5CQeGr/8A+VpN96blqSqhoTQnevRo7SsmLtFwaqCIRsEBHzE2kqQTOHNPccaspNEJCtwwJMr3XkIiWkIjXhIS1epjgXj1MxAtQopQx3HItEogJsnD7mXWCJQnD2AkrGylhW6REhunD84Ttd8vF2mGydvjBnKgZJ6DbcKLqlmtjMdkRTtaZ3QRK55+ZsJv5r1X/cjbztJgfw3lVXZa9o6NrlqWfDs8oKKkPNZwBEo4AAxBDpnHAU+o9fJKakvTddYjmy8+HYcujcTZ6N8gnR+nl+OiKHq03Wv60Ppn+YFqUeXFMJCrFCaP64BawS/smZg/qpZfja39M4GBxm45v36TueVr2J3lRn21VTH39ceU4T9ub7/8DAAD//wMAWoU/orMgAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:07 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "13"
+          ],
+          "x-request-id": [
+            "cc9de74012b56f61a846192cb2daace1"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748793796&engagement_id_cursor=B95A5E1E20FC95C47B9AF3EB1232F47E&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:07",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748851329&engagement_id_cursor=88AA5B596F0D1436023BE63FF34DE6B7&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+SX30/jRhDH3++viPLA03GZ/T0bCVVrr32q1HJVubYPVRX5kiVEEJvaDtdyuv+9ayfEEBLAgkCivlme78zszvrjmf32rtPpJmOXlgOXjv3DtHocJWXS7fQ7f3a+ebtX3LJNRpWlG2IUsyhWEElJELhCE1OGBmOjlI7i7vu5ZzkZnrsbL80l8IVhnnT+XklJCUMtGTK1sI/zbHZ5205Qg2agF/bc/T1zRenyhQalVgiSaJSCLTTZ6am3l5OpGxRumKWjolKKmxUUxWSc1psqs8HpJC/KQe4uL/695wF31jx1ReGfisEwm6XlfXsVY7LOXGZlcjFoFv41mZT3cim5UF9kqU9SPlk/PEvS1F3Up/NzdHJiPv54/PHmGG4dYFEmeRU1KbK0Fpu6Dm60UVulrJUUqDgEeQj0M2AfaJ/yNU4uHW10YX0OK5+Gz1HOinmq2uU4+mO9xAeuBSeffvo9shsy39rYb+l5mn1NO7+6aXblbvTJlcu9w5PrWgWdFV625ty94vv7zZCYSHIb2UAzg8rYUFtJlOEiFmDBBmYjJGKLkCiqkBJ4BBK505DIlpDIt4SEQWtImNwPSOQLQGKpNSi5IpEhRCCJUMaKqYAJZUCp1d9FA4ncIiSaKqEFYQ9DwncaErL8jTyRksbhdTEhtMKEyBaYVC68D2Q/MGkK+wxOQsGsQuaZQDQGDEgwKrRALUFp4mATJ2SLzQSFAJ+h0ezjxEWgZTdpHF6TE/YZoOJEiCdzMnfhfb43nLxAPwFDpRQGtP96uVaCUmqQ+olLQCQCgxs5UVvkhKNALhWSfR66VDtMlvrXp4T1iWpNSXOZ2UTJp1+i4x3AZFnY51BiKRGa8TgkQhhSXVS45MIGGGLE9WopGkpwi5RIwZmQlD5Mya5PXfvSTXjdTVpxwutuwv5H3SSwoEKtbQzEMBmRQLBAA3CLASfGqo2c6C1yIjRQon2gBzlRO82JatlN1Bt1E153E9aaErZ6cd1RStQLNJOIRoHiiiAwlEoYySMhlSE2FEHk565NkFDYMiTc30/2euQS7SBZ6t8CEgqtIaFiX0Yu8XxKAsMijga1UKGFOEQdR4wh6kByHtrVUjSUkC1SogCI1y5jrKeE7TQlhPF2mDQOr8wJViMXb9VMsOJErM4ZO9pMmsI+52pCJDIprEIdMsoCJZBRJcHGQgT+3UZO6JY5QcmW/4H1nBDYaVCWA+MTOVnqXx8TP3PR1phwsh+YLOv6GCWdvyphN3X/lIPLKvAsnx/CWVleFv1e75qlyZfDUwqo9KGGU+BEcIAhyBHTfCgS6hx8UZqS5MO1z+aK80O/4/EkHX8YZtNecjnpXdFes8/ih+ZcBsNZXmT5EVEcNVM+ysEdWm/sjwF7UC+9mFy7IwIHi2/p6O531D1LisE0y+uTLfOZq18uHedwvfv+HwAAAP//AwCgWnR/sCAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:07 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "fe51e73d441ec566c3c41453c469187b"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748851329&engagement_id_cursor=88AA5B596F0D1436023BE63FF34DE6B7&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748937792&engagement_id_cursor=0168365D789C323B75832760DF55B89C&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXX2/bNhAA8Pd9CiPPLXC841+/USJVDNiSYum2hz4YQqxkRhOps+QWQ7HvPkq25cyJnAiuahkIDCF3JKWTfuDx20+TyUV6l+XVLMvvwsVDfTlPq/RiMp18nHwL8ZDxKLaY15ELJhk6iSitFkZYZZg3JL3SMY8SEP7izXpktbj5lG1HGS6RNoH1ouv/KymRkTaSNKlN/G5ZrD4/jjNtwBCYTXyZ/b3KyipbbnK0NFoBIHCDYpNT3N6GeLV4yGZldlPk87LOZLi9hbJc3OXNU1XF7HaxLKvZMvt8/8+TIfC/m37IyjJclbObYpVXT+P1HIvnwlVRpfez3Z1/TRfVk7Xk9gnvizwsUr06/+avNM+z++b1/Oqvr+27ny/fbd/DozdYVumynjUti7xJtk0dsnlnbr1kk4mA4i3It0AfQE+BpsifGZTl884hfEq0922ENapVuV6qGXL13l8+nxNmbjKur375w7uOpR892e/5p7z4mk9+yx6KL9k2P/2SLcOAVxe2nnRVhrRnXnzI+PdNNxNMYqE914p85GInnEfGCTijyEZWiU4mfEAmhvPwo5EdZCJGrYS1il/JZDfgxzphOAWcMurhpB7Cp7D/cYzVya6yR0CJtVCEyDkLOKIoFmRZjMBMpBmLhO2EIgaEErY2o4RU6iAUPWooGvo5afNPwYSwJxOaCnyJyaX/cwRK2roegSRBK6OYiURzNDwSXIHzYVNhBrwXLOlEIofcTVAzLcJUZ4xE6n5I2vyTIDG9kXB1Hkjauh6BxIBwYSNx2ofzCEYkIubIGZ+E04nivnsnUcMhMaAh/IaJDiKRo0ZyPi2XbFou2YeJbFoufR5MvkvH5WIQXDodO5WEQ0mckKHQTiWxt5Q4u39K2znRQzqRWgIBiINO1KidaNaPSZt/CiXEeyoJHdeLB5NxKGnregQSy7ww3ktIHHGbeEDvudAs0T42Ers3EzMkEhIyvBRx+FjCYNRKpOynpM0/hRJOvZVwcx5K2roeoURaE2smVGIhRqtFZFTMImecDB+yxv1KtEoIBlSCzChFhh9uufiokbD2VPXqlotOwgShabl0Dyb1ED5l7CUmV+/95Qic7Cp7BBQQXhlhuMCYOyY9BR2h1+LKcSTw++3nDgobEorA0PehOryd6FFDUaafkzb/FEyoL5PQc6kzYdIW9ggliY8ocgSRVgLCH6k4YZZkYMKstdCpBAdWQuKlk8m4lZxJz7VWwmV/JfijlfwHAAD//7RXSwqDMBDd9xTFhTvNJNVoCtKTFIlp/CAaSWIpQu/eqG3FVVfdzv/xZuDNv0XX8ToHer182HyYC496ZaG2djBnhKZTz4ugJJAmLGBQQoTjCEAAvTntI2JOpIQicWqIh5PrJk0bOMRV01ehUB3iQ4PuBG04zWUjJhejNkpnOIlSlgKj1N9d68f/62D9ZXTTTDLD4L+XKdsvkldzk3dKL9RaPcrF+E1cP5rD8wUAAP//AwDGnCmgsSAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:08 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "541f7e1223cde1fc22ee8646829d28e2"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748937792&engagement_id_cursor=0168365D789C323B75832760DF55B89C&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748980966&engagement_id_cursor=FEB3BD30B875075037CF1A3647D1AAA0&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXX2/bNhAA8Pd9CiPPLXAkj0fSb/ynYsCWFkvbPfTBMGIlNZpInSW3KIp991FKbGdN5FZIFMuAERC5O1Gm9DOP33+bTE7ml3lRz/LiMg2um+FiXs9PJtPJh8n3FE8Zd2LLRRM5AcMtj9pajCCciB4wMpBZGqsoQnby4qayXp5/yjdVBkmI28DNpDf/V0ScCW1IaKFu45ercv35bpxpA0aAuY2v8n/WeVXnq9scTcYIyZkEYJs5youLFK+X1/msys/LYlE1mbi5g6paXhbtl6rL2cVyVdWzVf756tu9CvjfPV/nVZVG1ey8XBf1/XhzjeVD4bqs51ez3Y1/nS/re3Mx2KzAVVmkWepfLzj/OC+K/Kp9Pn/GszP76vfTV5sHcecRVvV81Vx2XpVFm2zblcgXnbnNnG0mBy5fAr0EfAswBT5l/IGivFh0loipND+8HGmOel3dTNWWvH4TTx/OSVduM85e//E+ho6p73yzd8WnovxaTP7Kr8sv+SZ//iVfpYJfX9nmqusq5T3w7FPGvy/2QAkYeGa8y4ih4ogGUAM3koEWAl0nFBwSCkkBiCj3QqFRQ1E9nahDMuGmNxOkI2GinkIJN4qipKi1NRTRg3KoUCirvfcAnUrkkEoMgJKc2F4latRKqKcSOqQSIfsr4T9Tchr/HgESegIkinsRlQseLVBQQvr0M86YMmSd8V51IqEBkUimUtOVRnuRyFEjYYz37Lm2Bc/MBNueC/swSSXp89PNZBxMdgv7CCdBpl0kyrQGyqf312ekgwMWkCI4Iux0ogZ2IpiQaq+TcW8mGvox2eYfQonodTLB9mRyJJvJdl0fgSQGclEF5jV6JApaRq80BhM5z5jsRqKHREKa8/TZ33HpUSM5lo6rRYLQGwn+2GeM9VzyFC0X6cxlNgiTCZAuOLIZZ4aTDKkFM8p2KjEDKlGAnPGUdcwtF8h+THYFz+xEN05kLye6abl2h5lxbya7hX2EE01OB51eTaY8pa4rWq50pq3B9Lq7ELucIAzsBFMvKPc6oVE7UT13E3Wg3UQ3WwPI3kr4kbRc6gk2E5sZkBwVV8EzFzVmHCKl0wmPninX2XIhGxiJTH/NESMh6odkm38IJKzXuaRFwvRxINmu62POJY5FAc6CdT69wcRSo2VJqoy4Ap2FTiR8QCQakxAwej8SMWokDHoq2RU8LxPGGya8T8fVlMgp0LMz+Q8AAP//nFbJCoMwEL33K4oHb5pJjEsK0i8pEtO4IC4ksZRA/70ubcVTS6+zv3nzYP78uH7VyfEyBzqdvJtsmCuPamWhMmbQJ4Rs0PHcKwgkMfMYFEBxSAEERNeAURFyIiXkMSOY+3bqJnXjTZDLuit90beIDzW6EbQB1eeNmEyMSvcqxTFlECQRgLvT69v/TbLuMrqurUwxuK9jSveH5FRcZ22vFmqNGuVi/CSuazs8ngAAAP//AwA8uvTVsCAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:08 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "11"
+          ],
+          "x-request-id": [
+            "0ba7cdc956105ea4b06286970c163563"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1748980966&engagement_id_cursor=FEB3BD30B875075037CF1A3647D1AAA0&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:09",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749038600&engagement_id_cursor=EB1E30BA0ABC62161A06A657F62708FD&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXS2/bRhAA4Ht/heBzAuzsY2aXN+4rKNA6RZ22hx4EwaJdITaZinSCIuh/7+pFqbEpm1AkUzfKM7NLzvrD7n79YTS6mNwWZTMuytv0cL94nE6aycUoG/05+priKWMnNpsuIhe54jlXiIoQdMid5AGi0MhQKAyCX7xZVTaz64/FpspIlGIdWE26+jshchDaoNCC1vHbefXwaTcO2jAjmFnH58XfD0XdFPN1jkZjNEqmSXJY51Q3NynezO6LcV1cV+W0XmTi5g3qenZbLj+qqcY3s3ndjOfFp7t/HlWw/73zfVHX6akeX1cPZfM4vhhj9lS4qZrJ3Xj74l8ms+bRXLRpwF1VpkmaF+df/zUpy+JuuTo/h6ur/N2Pl+82y7CzgHUzmS9GndRVuVrKZR+KaWfuYsplJmdcvWX4lskPwDMmMoFPFBXltLNEZkp886+R5mge6tVUy5LL8MfTKWngZcLV+59+D75j5p0P+638WFZfytGvxX31udjkTz4X81Tw4r4uBn2oU9oT654y/n3TjUQKzoCElDwSSXAJCrPBeJIWrLN5JxJ5XCTAJRk6YySI/ZC0+a+BRPLeSKQ+DyRtXw9BoqSzAokpbrWMMjCVBw/k8tzF3KlOJOqISIwBxgxIsxeJGjSS9J39lGwLTswEM8YzrvowwQUTfiZ7ybaxBzgRWnPA4DgpZSVjGqIU6eTlogmcSdvpBI/lhBhLaJE4cLXXCQ3aiRb9mLT5r6FEUm8lwJ5T8v6XcDkAJm1jD1CiNbNRO2sYkyEY8tY47yyFqAR5ZTqV0FGVMEJDev9uAnzQTM7lzLVkonRvJkyex2byPc5cEL0D52MA7UVEL4lBzIHSBUU5bWOnEn1EJaDJSAnPKBGDRmJMPyRt/mmRcJYx6IdkUSIyQeeBpO3rIQcu4bWWIh2gAjeWASoUgCI3IbIgKO9EYo6NRCPuRyIHjYRkPyRt/umR8J3T04uR8Gd3koEcuNrGHqDEOwEQLdngfU7MeZ9+6hBAmUg5+/aG1ipR7IhK0n0IORncfy1Rg1aCPZXgqyrB/kqevZYMYyvB74DEyMgM48FLiwGjCZB4OC6F8YBAqhMJHBGJUCCEIRJ7kQz7vAWsp5JtwSmZqA9syUTRi5msSmQm4Uw2k21nD4ASjc8xiQgOvZWkAnktFMkYrHUBfScUfkwoRgInhP1QcNBQCPs5afNPz0RkwHsz4fpVdpP/AAAA//8ivcllRmQmUYgFKVTKS60oiS8AGVxaBImEjJKSgmIrff0q47zEJN00IwNgj0DX0iDNwMTQ1MTAINnALAWYYJNNE41SUw2SzC2NDBP1qoC2pRZn6wJ9nJ6Zl66XnJ+rn1iQqV9mpI/wZ7E9Il7ik0uLivOLbA3NTSwNLAyBpqihZFaYPKH8qgZ2enFmVaqtoYEaNC3ZoqYjpYzE4vjc/CJwzJYUlaaCBeEaIWULVy0AAAD//wMA69zxeqsgAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:09 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "bfb27c2f5b0accfc695d5db718e7c60b"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749038600&engagement_id_cursor=EB1E30BA0ABC62161A06A657F62708FD&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:09",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749081792&engagement_id_cursor=F9DA6617EC6DB475E7D83574FEBBCE6D&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+SX227jNhCG7/cpDF/karPmmRwDQUFR4qJAmy2aHi6KwtDatGMkllJJzm6z2Hcv5YOck+wIhhMZvbKg+Yekhvz8D7+963S68cQlxcAlE/8wKx9HcRF3O/3OX51vPu4V92LTURnpMkRZyAKFhQ1xSIywGgIgWMtACyRV9/0ys5gOr9w6C5jgdBVYTrp8L4UgmCoQVFG5ik+ydH5zP44VIKAIVvHM/TN3eeGylUZJhCgwzCVWeKVJx2MfL6YzN8jdME1GeakU6xXk+XSSLD6qSAfjaZYXg8zdXP/7JAM9WPPM5bl/ygfDdJ4UT+PlGNPnwkVaxNeDzcK/xNPi6er4Sn2dJn6S4sX64WWcJO56sTs/RxcX+uOP5x/X23BvA/MizspR4zxNFmK9qIMb1WrLKRdKggg/ReIU8d8Q6iPax+qZJJeMalNYn9BHR8PPUczz5VSLlPPoz+clfuCF4OLTT39EYc3M9z7s9+QqSb8knV/dLL11a3186zKf8OK6loPOcy97Zt+94vv7ekioMDq0AqyVSDLJKdOW0ghxE0oltKmFhB8QEim5VAgUbIWEthoSgGaQVPpXhkT1Eelj1AQSVXLF4Dggqeq6ByQKTEiotiEPbUA1V0YDDoEIpbilUb2TiANDAuXPVkh4qyGRrBkklf4tINnYwoshoXIXJJ9+ic5bQElV2D0osRHYQEtsMbaKA5iAaYS0CVDg7SIStZTIQ1IiMJFKMX7ElBxLv7WkpFG/taTkf9RvMa3B/3NrYKEkIAgKuDaME7CUgQoe/19sIFGHgwQjJgATetSXEowbeskm4XUxwaTEhDcxkzKF9dlOM2kHJpvC7sGJkRaIJoT5O0mJCWUUc0kif0wlxmH9vQQOzAkju1ou2WpOKshfiEmlf31KaB+TxpTsNpOWtFxVYfdxE8xwYCJiqcFRoCkBqZggSthIKhPWuolAh6TEQ0IBo+1u0m5KhGhGSaV/C0oIbkwJOZaLSVXYPSiJDBeGUwuR1JEKZWioQlzgQIiQIqRqKcEHpIR6dLngbDsltNWUYISaYbJJeGVORNlz0UZuIkpONgbU8p6rKuw+bmIZNxgBMVpw7o8vEYYRKxVQIaywtZyQQ3JCJBd+DtjKCW81J5I2w6TSvwUlTDSkhPY5HAclVV33MRMtkeaCRkYEoITxd5GQK/+SAhhFeC0k9NCQKKq2m0m7IRGsGSSV/i0g4Y1ariUkj49GSyGp6roLks7fpbCbuK/F4KYceJ4tN+GyKG7yfq93R5P48+mYICXhFNAY+Y6HITREYkSBDXlMnEOfJRAcf7jzs7n86tR/8WSaTD4M01kvvpn2bklv8535D5t9GQznWZ5mZ1gywBSoxCcPYF3Hd/F6slh6Pr1zZxidrM7S2cNz1L2M88EszRY7W2Rzt3hZJS4N+N33/wAAAP//AwB1tMyvqiAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:09 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "2cb21f63bfd0b6b602e1c6d91f286a35"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749081792&engagement_id_cursor=F9DA6617EC6DB475E7D83574FEBBCE6D&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:10",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749139371&engagement_id_cursor=EA70A563EC6B986C1DCD58A70399C825&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SXTW/jNhCG7/0VRs67AD+GM6RvlEguCrTZotm2hx4MIVZSYxNpa8m7KBb976X8IbtJ5I2QaC1fDMHzDoca8tHMfP1hMrnIbvOinuXFbXy4bx7nWZ1dTKaTPydfoz0qDmyLeWO54MolgRCIHAQnXEIykZ6nqRXCCbAXbzae9eL6Y77zMoAIW8Mm6OZ/QhRcaoNSS9rab5fl6tOhnWvDjGRma1/mf6/yqs6XW40mxpUkoZE032rKm5torxf3+azKr8tiXjVKudtBVS1ui/VL1eXsZrGs6tky/3T3zyMP9r893+dVFZ+q2XW5KurH9maNxVPmuqyzu9l+41+yRf0oFme7DN2VRYxSP9/h+q+sKPK79fn87K+u7LsfL9/tDuLgCKs6WzbLZlVZrMV2nYl83qltYq6Vggn1luFbpj4INmViKswTTnkx73SBKZcPLkeMUa+qTai1y/tf/OXTmrjyWnH1/qffvesIffBmvxUfi/JLMfk1vy8/5zt99jlfRofnZ7ZZdVVF3RNnHxX/vjkCSsLRWqaNIQFMqVRrVFaCc4lmyKkTFDUgKGA0xtiKjoKiRg0KYT9OWv0pMAHZExM5VeZbmFz6P0ZASZvXF0DiGLeGB06eMZtKF1KXYqIIKUKDAJ2Q4ICQYMSTaw7HqwmOGpL2K/JMSFr9KSBRrD8k6jwgafP6Aki0C94GBOYNJT7xzqZJ0EE5aSxn+PBzsYeEBoSEFEDUfAOScbdcRveDpNV/T0jwA9tAwp8NycYFDnq0cUPS5vUl7ZYRoLiNowgpobzXTDLpUheHE+NAYSckemBIuOHmeLsFo4aEeo4ldIqpZHPjZeSkNyT84dUY61RCrzCUKCVVbK2CBJ8KpUHJCI0WAQRzaL3tpMQMSUnzo6P2jIcS7DmU4CmGkpYS6k+JPI9Sgq8wlFjvKDUhDgDSWuLGCecUeKlsYrQxrgsSYgNCYpAjkG5BPMdSwlnPWrJ3+M6YQNNx8V4dF5zTWLJP7As4QZ1ydOQSYDIAOeaCi1c1CEaBrKNOTviQnAgwJIRWRznBUXNCPYsJnaiYrCkR2JsSEOfScr1GNZFBiqAdyFhUKPEs4YkO3HoO2rNH3eeeEjEkJZobpknKo5TQqClB1Y+SVj8kJf8BAAD//8yXS0vEMBCA7/4K2UNv3czk0W6EInvoz5CSrdndItuWpBUp+N9Ns7phFS1FlB7zmCTz+GYy31HCZjUmnhL2OYEutJZc7PoLSDjLMaFciHzL860QlKXgRsJxwNPkS74IkLC/g4SiKyMICD9/uZbdlyDMpCQI/DMmG19MYA4mm7Ezgckv10KKSbDsFCi3D+PGVa1fuqIdT+7N2Q3HrmvtHSEDq9Uu3lOXwmUsYQ8cBQcoIXlkkpdCUa1hl0qKaj2427R9ip3Kh6o+rMvmRFRbkWdKgqL2PnimKHtjG5NhyqVrOySH6ArYj/UpZiP/dFsNOkOI3qMpu46k1VHZ4tQY79vO9NpPXgTPZrt5fQMAAP//AwAust5wriAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:10 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "51160edcdfbaea12162dab9631366ddc"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749139371&engagement_id_cursor=EA70A563EC6B986C1DCD58A70399C825&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:11",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749196940&engagement_id_cursor=43E162455EA4EA552370455594647642&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SX227bRhCG7/MUgi58FUd7nNkVYBQkdxkUaJ2i7uGiKARGWsuCLdIlKad1kHfvkpJFn2ibUGRLgAQQnH/2MMuP//Dru16vn0xdWo5cOvUX8+pykpRJvzfs/dX76uNecSs2m1SRPiAaoiNJQ2PiwEYGMIwjQ0KklmME/ffLzHI2Pnc3WVoAilVgOenyPgIwypUGrjiu4tM8W1zejlOlieZEr+K5+2fhitLlK41Cwihjimu/tJUmOz318XI2d6PCjbN0UlRKuFlBUcymab2pMhudzvKiHOXu8uK/Bxnkzprnrij8VTEaZ4u0fBivxpg9Fi6zMrkYNQv/kszKB3OtF3+RpX6S8sX68VmSpu6iPp2f7clJ8PHH4483x3DrAIsyyatRkyJLa3FQ18FNWrXVlLWSESYPCfjfb0QNCRty+UiSSyetKXwo2b1Hw89RLorlVHXKsf3zcYkfuBacfPrpD2taZr61sd/T8zT7kvZ+dfPsyt3okyuX+4QX17UadFF42SPn7hXf3rdDEoFHQseWUWRUgg2sNrGUsQoCZjVTrZDIbUKiOKUEFd1jSAC6QbLWvwUkgnaGROBzkHz6xR7vACXrwm5AiadBqthaKWLgkpBYAVGBQFRAYxTtVgJbpIQTySWgftpKxE5TQonshkmT8LqcUFZxIrEDJ1WKGIo9MZOmsJu4iQpiE4CQsaCCMhrwSAlNJedxzLDZwwNOcJucABOCqf1uuTq6Cb6Nm1SPPB9S1pmSB43GjlKC38FMDHrjCFCHQRwR7f9EIIXIiooZw+77agOJ2rKZIBf8aUhwpyGBjl4Cb2clHhLdHRKxLy3Xd7ASzmWkCaAxFSCSs8AqArHlBqhAsK2U6C1SIplGIPAMJXynKaGUd8OkSXhlTqBuuaALJ1C3XHpPOGkquwEoUmFsDQ9NaEX1RUCJtqjBUGIoMkLaQFFk26AoTp8GRe00KOsCvZCTtf71MfF2IjtjwuV+9Fzrum4ACbGMAAstlSzkUiqGIbOhioOKFwha3UTRbUIikKCma7fcy55LdYNkrX8LSFinD5MlJPffn7vqJevCbkAJGqrCUFf/OBLGcqusNB4PQBABh1ZK2BYpUUIiUUw9TcmO91wEumHSJLwuJ4xUPRftwkmVwodS7YeZNIXdgBPBKRPWf5JIFlPlrURJYuKIWw6RCll7y8W3yQlnAH5dT3Mid5oT1RET9ZaUMOxOCd8TN1EvpaT3dyXsp+7fcnRZDbzIl6dwVpaXxXAwuOZp8vnwlBGF+lCTUyKoFISMCUy4FmOZMOfIZ9SMJh+u/WyuOD/0O57O0umHcTYfJJezwRUbNPssfmgOZjRe5EWWH1EUmglCBR7cofUm/hywB/XSi9m1O6LkYPUwHd19kPpnSTGaZ3l9tGW+cPXNdeLy5fLu2/8AAAD//wMACv7oXK8gAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:11 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "12"
+          ],
+          "x-request-id": [
+            "de93a81a0ade96a51ed6750e79a8b666"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749196940&engagement_id_cursor=43E162455EA4EA552370455594647642&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:11",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749240147&engagement_id_cursor=43124E32A52F187B2850DFC3E36C8B20&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9yXS2/jNhDH7/spDB9y2myGHD4NBAWpx6JAmy2abfdQFIbWZhxjYymV5GybxX73UrJj5yUngutEruEDwfkPH8P5achvb3q9fjJxaTl06cQ3ZlVznJRJvzfo/dH75u1eccs2HVeWPlNIKTU8pCyygEFMjbbCRhJCYJpg/+3Cs5yOvrgbL82EYkvDYtJFvxSCElRaoEK5tE/ybH55206UBo2gl/bc/TV3RenypUZJoAq04EAkLjXZ2Zm3l9OZGxZulKXjolKKmxUUxXSS1psqs+HZNC/KYe4uL/554AF31jxzReFbxXCUzdPyob0aY/qYuczK5GK4XvjXZFo+XJ1aqi+y1E9SPls/Ok/S1F3Up/NzdHpq3v948v7mGG4dYFEmeTVqUmRpLTZ1HNy4UVtNWSspUH4Iwv8/UhgAHSA+4uTScaMLDhi5lxp+jnJeLKaqXU6iT49L/MC14PTDT79HYcPMtzb2W/olzb6mvV/dLLtyN/rkyuXe4dlxrQadF172yLl7xfe3zZAQakISyYAFQUwCZCERllhliNFaC9EMCd8dJAicawDC5UZIsNOQEMLaUbJ2eElM5Eeocx7oszFZuLABF09h8uGX6KQDnKwjuwUooWWSaYMo/ecbOY+t5rFCgkCsryy8ERSxS1CoZIoLvbmaqE6DoqAdJyv9a2BC22PC6H5Uk1Vct4BE8ECAQG6sADASLFfEGGtMyLVP1bgRErlbSDhDwM3VpNuQCNkOkpX+NSBBaA0Jyj2pJavAblNKQuEzkgJYEWoTU8W14ioKaQAhlbSZErVDSojwgPof30gJ6zQlBEQ7TNYOL8wJq54mnLThhO0VJ+vIbgFKICmPIQAtI0l4JIKIMm5p7GnxhUayRlD0LkFBQUEKsvnOJToNimxZTuQrlRNWP01ka0zo/dToKibyPygnLIykDQxVQSythljKGKkMophRjSyImijRsEtKAH1R47iZEtlpSgRvR8lK/xqUENaaEqL3hJJVYLegRFpFQipsbMFwn5yEWi5UZAlKKkTQeOnSZIeUoAaQSpLNTxPsNCVat6NkpX9hSlR15WK0DSWqriXkKUpOok8dgGQV1y0gIWDRGh3pKIxUoGNllLLMEClCo4Pw/vdiDQndISQMpOb+Urf5ZcI7DYnEdpCs9K8BCeetIQG1H5Cs4roFJCE3sa8bSujA2hAxJBFwE+gotsp33n+hrSHBHUKCEoUSVOg9hmRf7luqfpVAe0j4/+2+1fuzEvZT93c5vKwGnueLUzgvy8ticHR0jWny+fCMgpL6UMMZMMIZwAjEGDUb8YQ6B5+lpiR5d+1nc8WXQ7/jyTSdvBtls6Pkcnp0RY/W+yx+WB/McDTPiyw/JpJpqhAVHNyh9cb+FLAH9dKL6bU7JnCwTKbju4nUP0+K4SzL66Mt87mrO1eOVS+BN9//BQAA//8DAHwe6UetIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:11 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "b41a685ec9bcc32d3eefa3f85c23abc0"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749240147&engagement_id_cursor=43124E32A52F187B2850DFC3E36C8B20&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:12",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749283380&engagement_id_cursor=D5AFEB1869CBBD33D1E05AC9EFB88697&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXW2/bNhQA4Pf+CsMPeWqac3ingWAgJaoYsCXF0m0Pw2CotuIYjaVMktMtRf/7KNmxc5MTIXEivwk655AUyQ+kvr/r9frxJEnLYZJO/MOsehzHZdzvDXp/9b77uM+4EZuOq0ifcxk6EyAR3BFAJVjk0HFJA9DaWd5/v6gsp6OvyXWVZkKzZWDR6eK9FIIgVVpQReUyPsmz+cXNOCoNmoJexvPkn3lSlEm+zFESKNeouSaaLnOy01MfL6ezZFgkoywdF1XmdTQuiukkrT+qzIan07woh3lycf7fvQq4NeZZUhT+qRiOsnla3o9XbUwfCpdZGZ8P1wP/Fk/Le30hiGX6eZb6XsqnF4zO4jRNzuv1+dWdnJiPPx99vF6IG0tYlHFeNRsXWVonm3omknFjbtVnnUmA8H0Q+yA/IxkAGVD5QFGSjhtL2IDQO5vD91HOi0VXdcmR+/PhFN9wnXBy/MsfLmzo+caH/Z5+TbNvae+3ZJZdJtf58WWS+4KnT2zV6rzweQ8svc/48b7ZiYxCpJwzLZlxBgSJmHWWBIoZxSSXjU74Np1IIMgE3+xEdNqJbMlEvqUSTlsrAb0bSuQLILEeBiWGshAMRBQi5aRRlnDOkRPWjERsEYkgUgBqlBuRyE4jEbwdklX+6yOhA4D2SO7eMzqKZDWvzzlJTKQijCIE5pGgtpoIywyPjPHP2jUikVtEIoXiqBXwjUhYp5EgQjsl64JXZiLqG5dqw0TUNy71GJPjT+6oA07WM/sMKI5YKkOwNAw9EIecB1IJawIaRY6I5tNEbRkKA002Q+n2lUu1dKLekglnrZkg243TRL0AEgQk2gRMOcrQRgI5Un+KgCJGSZTQiERvFYlELYDojUhUp5EI2Q7JKv/1kfgrF2mNZFf+S1bz+gwkIrIRWq5ZAFEgnbCWKmZciFoqp6xtQCIBtohEC80VUWynr1xAW165VgWvy4RAxQRFCyZVCRvwHWGynthnOIkEDzWNCIJVyBiVlFhlGLgACVfB3dvn2glu0YlSTPixsM2HSbdvXFK0Y7LKfwslFForYWI3lKzm9RlIAmo0CAgDAkb7/xHLLSrqnCFoLaGkEQnZ7mEi/ChWEHcRiWiJRLwpkvZHCbu7NTqKRLwEEv8bYiLDI6pDIEprdBoiEJaHkVBoGpHQ7SFhiAwk0VxuREI6jQSBt1OyLnhNJuoz+D1PBoQ/mcmihA3w7j/rPSbHn9xRB5ysZ/YxKL2/q8R+mvxbDi+qluf5YhnOyvKiGBwcXNE0/rJ/SkBJva/h1O9VzgBGIMZUsxGPSZLAF6kJxh+ufG9J8XXff/Jkmk4+jLLZQXwxPbgkB+sPLX5ar8xwNM+LLD9EyTRloBnfuwX2Ov6Y2b166MX0KjlE2FvupsPbO6l/FhfDWZbXa1vm86R+uSpcTNu7H/8DAAD//wMAqjZ3Y68gAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:12 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "76facc6af1379197d702321e72568ab8"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749283380&engagement_id_cursor=D5AFEB1869CBBD33D1E05AC9EFB88697&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:13",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749340945&engagement_id_cursor=C513AFA5F39D028991E90F06B5DF681A&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+TXzW7bOBAA4Hufwsg5AYbkcEjmRolkscA2XTTd7aEHQ4iVrNFEai25xaLou5eyYzl1rDZCosbC3gTP8EekPnP49cVkcpRd5UU9zYur+HDTPM6yOjuanE7eT77GeMy4E5vPmsgRSquk9UEgd9yTJeEdGOm0STRLQzg6Xres5xcf8k0rgwrwNrAedP27IuJMaENCC3Ubv1qUy49340wbMALMbXyRf1rmVZ0vbnN07JpJYqCJNjnl5WWM1/ObfFrlF2Uxq5pM2sygquZXxeql6nJ6OV9U9XSRf7z+714L+GHON3lVxadqelEui/p+vOljvi9cl3V2Pd1O/Es2r++NpTbTuy6LOEj94PyLf7OiyK9Xu/PKn5/bl3+cvdxsw50NrOps0fSaVWWxSrardchnnbnNkKtMDlyeAJ2AfgtwCvwU2Z5GeTHrbCJOpdr5NOIY9bJaD7Vq8vovf7Y/J/a8yjh//ec/3nUMfefN/i4+FOWXYvImvyk/55v87HO+iA0evLBNp8sqpu3Z+Jjx7bhbCRnruUJSUgYbFApHaJ1LHaSEFHinEjmkEoYMIpQxKyHZT0mb/yxKVH8lu5/GPSVn/t0BIGnX9RFIROIJELzUIJVCnjgmTWoNOceRqaQTCQ2IRLDI9pdIxEEjMT2RmGdCgg0SEH2QYINE6JEcJeYJlDgXLKZKW9QovOIkGyCpSjlo6QE6lagBlXAykgO1fexXggetRPGeBRd/RiUMeyvhNBIl7cI+QklKQiI3EO8iCmWiUBvmnU1EIORS204lesizRBAJptuiboxKxlJwrZXo/krE/6jgMsGAFoZRqoQmUBC45IEgOGFI7v5fbJGYAZGgjlhJ6lEXXKYfkjb/NyPRq4KrFxLdINleZA4bSbuuj0CCKmVOx48+cRAS6XwwjlJug2WxEEPXhYTBgEgk8MiW0c9PEnnQSJToh6TNfw4knPVGInAcSNp1fQSSWFwxR156B6RVvArIJAVlZQjBpIi7K7FFwoZFgvFqwtmIkYyl3Fojof5I2K+QHMil5CnqLeA68cyDDRycEByFdloEcA61lOlu5blVwgdUogCk4Jp+ruSwLyWsPWwfyGTbYGAn3wEAAP//1Jdfa4MwEMDf9ylGH3yz3iVxSQQZRdtvMSR1aSujKomOIey7L9qt0sJWpIx1r5dckvvzu9ydJT2SnhNGJ3DSq7CI/pOxZHTsFZykaeKKt5tNIGVJuFgwkSyRr5x0uUqQym85ob/JifvVqED2Myf8pjnhYmLLJf6MEhrBlJbrQAmep8aNUnL06yVI7p/6jbNSvzVZ3R/cmkMQdk1T2ygIOlqqtb8hILj0JWyAYcgAcnh4ppLloSJaw5pLgmreudu0ffGdxdui3M7zah+ougheSTDaaR/HuGR5a2xlYuRMUsFQoHcC69f6JV694em26HSM4H3mUnyaR7Odstm+MkNkG9PqQXhUHGoL3L1/AAAA//8DAF4i0amoIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:13 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "8a903d79a8950870a832023c3c67ca77"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749340945&engagement_id_cursor=C513AFA5F39D028991E90F06B5DF681A&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:13",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749384181&engagement_id_cursor=DDC450F900D4C5AA48CE17FDC4EFC139&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SX32/bNhDH3/dXGHlugSOPP45+o0SqGLClw9JuD30wjFjJjCZSZ8kthmL/+yjZlt3EciJ4suU3Qfe9I3nkB3f3/afR6Gp6n2blJM3uw8dj9TmbltOr0Xj0afQ92INixzafVZYrZ4SLtPeOxaSsBiOdcZYjdzbyscWrNyvPcn77Od14GaGZWBtWi67+a6U4QzIKCfXafr/Il1927YwMGASzti/Sv5dpUaaLtYY0hOgKJYDexMjv7oK9nD+mkyK9zbNZUUfb7KAo5vdZfagyn9zNF0U5WaRfHv555gE/7PkxLYrwVUxu82VWPrdXMeb7zGVeTh8m241/m87LZ2sptVY/5FlYpHy1/vavaZalD/Xt/Opvbuy7n6/fba5h5wKLcrqook6LPKvFts5DOmvVVkvWSg5cvgX1FugD42PAMdAepzSbtbqIMRNPnkZYo1wWq6Vql/e/+ev9mhC5Vty8/+UP71qW3jnZx+xzln/LRr+nj/nXdKOffk0XweHVia2CLosg23PxQfHvm3ZKuMEkvGkvReItIQqt0TPjtXM+irxspUT2SAmREFwKZQ5SgoOmxJhulDT6E1OixsDHknWhRFWUIFwIJU1ij6AkFioBYuRE7FVChFFESC5BG0ehykStlKg+KdGaB0Y0HqREDpoSLbpR0uhPT0moJaIzJYxeouTa/zkASJq8HgGJTEgw5g0kNgYP6K0PBcVA7Gx46l63QqJ7hMQwyZnZxrhESJTsBkmjPwskpjskLzZcw4CkyesRkHjuHVeCMx8xQATJrYA40oIipsiYVkioP0gkKEaSFMmDkAy732KsIyVbh9NiwqHquFB1wKRyCR0XuwxMtok9Zi5B6zwn7qXmlpQiH8YSZFpIZWVinjafW05Mj5wwLpnY0eznRA+aE4JumDT6c1Aiu1PC1IXMJU1ij6AEwHgeIQdLsREIwLxOYooTZVBEFtso4dAnJUKAlAYPzyXDpkRRN0oa/ekpCS0XdqfkQmpJk9dj5hIkLTAxhlmPxmlSyEUiMPxSEnxry8VZj5BwLonCVg6XEjFoSFhzwte2XI3DKTExH6B+81K+GpOVixqLFyeTgRSTbWaPAcXGsVdJ7LSmMJok1kRx6LYiJKeYE609F+c9goJAIJghdhCUYVcT3bGa6HNUk9Wbl2PGO2OCT5/GQKuJ/h+qiQcEEUMERhjtnGXAdYRWgiBSlPhWSLBHSEI1MUwCyIOQqEFDonQ3SBr9WSChzpBweZZa8h8AAAD//5xWSw6CMBDdewrDgh10WoqlJsSTGFJq+cRQSFuMIfHu8lEJK43b+U/evJn54+diP7Jkf54MPa3uLuumwL1ZUKic6+wRoSHSIg8KAgnjAYdiXOQxBZBwuEScylgQpSBnnGARDmM2Za/B2HFZ6zKUbYNEV6MbQWuf9rQCk8ne2NakmFFOCYtx4m/Y+tZ/I6w/l27rQaUY/NcwpdtB8iphs6Y1M7TO9GoWfhyXC7x7PAEAAP//AwCkpqqlrCAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:13 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "b7ede603e799751b7f1d6d30af92d4f7"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749384181&engagement_id_cursor=DDC450F900D4C5AA48CE17FDC4EFC139&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:14",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749427518&engagement_id_cursor=E0304C0B09497DDA1027B3A5048868FE&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SXUW/bNhDH3/cpjDy3AMkj70i/USJZDFjTYum2hz0YQqxkRhOpteQWRbHvPsp27CyOkgqOaunBhuD7HymT98P97/svk8lZdp0X9SwvruPDbfM4z+rsbDKd/D35HuNRcS+2mDeRM1RGWh2kAOFMigEDaCTvE24VOI9nrzaZ9eLyY36XZSQJuQ1sNt38ToiCgzYIGmgbv16Wq0/341wbZoCZbXyZf17lVZ0vtxpNTMXlyXADsNWUV1cxXi9u81mVX5bFvGqUuzeoqsV1sf5TdTm7WiyrerbMP918O8hg/3vn27yq4lM1uyxXRX0Yb9ZYPBauyzq7me1f/Gu2qA/24uzu/W7KIu5S/3jC5T9ZUeQ36/t56y8u7Jtfz9/cXcS9K6zqbNksm1VlsRbb9Unk81Zts+daKZhQrxm+ZuYDk1Mmppw/kpQX89YUmCr1oDjiHvWq2my1Tjn3fz0uiQuvBRfvfvvTu5ad7/2xP4qPRfm1mPye35Zf8jt99iVfxoQfP9hm1VUVdY9cfVT8+6qdE2bJuSSVXoKW0qeaKR7AGR45Ec76Vk5Un5xopgGRqSc5UYPmRKtumOz0p6BEYHdK+Dgo2Z3rEZB4b5VDbYlMYmRQsZcEimUs08TKFGUrJNgnJDJKNEkzYkgQu0Gy058CEhCdIQH9HCTv3vvzAVCyO9gjKBHkIgtaeK8dR6d8oGCEsUz7+AHTSgn1SAkapgxq5KO2XLqr5dKn4URPY913s1wxRU3Vw+IYaDPZH+wRnIRE68Qp7bzjqbMmuACeMR9tT4IU0lZOdJ+coGpuRdGTnNCgOSHqhslOfwpKhOlMiXw4tQ61m+wO9phuIhPOeSxeETA1XlF0WoookanwjOih+9xTYvqmJH7BiCkZi+daUwKdBpMNJWIcveQlLFeSCkegZSxKm6BDb4AnIQ3oKWirVBskwHqERCOCFKSftlzDHkw4U90o2Sf8XEy4aEYTJTtg0qREskZjudTxnNjYPhQzThELAWSagvZJAiyFWO9Kto4mwHvmBBUbdTOhjpjQ6SiBboPJhhIxGsv1ApRww7k00WUZ1KnlwhCzljktdaxSF3QrJaJHSgwDowGeGUyG3U2wIyV4UkqoOyXPWq6BUIIvQIkMITor4ExSYOQBk5QnRkbnlQZOBzPanhLojxLkIJUyxjxNCQyaEs6gGyb7hJ/MCTaei4sunGCD1oEh752T/wAAAP//IrvRZUxkRlGIBSlUykutKIkvAJlcWgSJhoySkoJiK339KuO8xCTdNCMDC3NLXUuDNAMTQ1MTA4NkA7MUY0uTZNNEo9RUgyRzSyPDRL0qoG2pxdm6QC+nZ+al6yXn5+onFmTqlxnpIzxabI+Imfjk0qLi/CJbYL6zNLEA5kEjNZQMC5MnlGfVwE4vzqxKtTU0UIOmJlvUlKSUkVgcn5tfBI7bkqLSVLAgXCMk2LhqAQAAAP//AwCllqVYsiAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:14 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "11"
+          ],
+          "x-request-id": [
+            "7d293035e16eebfa44816b20904c2bab"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749427518&engagement_id_cursor=E0304C0B09497DDA1027B3A5048868FE&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:14",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749484932&engagement_id_cursor=4FFA5531047F07E36BC1B94931CF1746&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SXXW/bNhSG7/srDF/kqmkOycMvA8EgUVIxYEuHpdsuhsFQbcYxGkuZJKddiv73UbIt50t2BNeJfGFD9nkPKR3y0Xn57U2v148nNimGNpm4i1l5OY6LuN8b9P7ufXNxp7gTm47LSF9qCAJJjUcIqBBCA6CV9JFECtEg9N8uMovp6LNdZWmUDJeBxaSL/6UQlDClBVNMLuOTLJ1f340TpUEz0Mt4Zv+d27yw2VKjJAhQSBlDsdKkFxcuXkxndpjbUZqM81LJV3eQ59NJUj1UkQ4vplleDDN7ffXfowy4d88zm+fuKh+O0nlSPI6XY0yfChdpEV8N1zf+JZ4Wj+aSYqm+ShM3SfFs/egyThJ7Va3Or+H5uff+57P3q2W4s4B5EWflqHGeJpXYq+pgx43acspKSYHyYxDHoD8SMQA6oPKJJJuMG1PYANmDreHmKOb5Yqoq5cNv4dnTGjdypTj/8MufYdAw9Z0n+yP5nKRfkt7vdpbe2JU+vrGZS3h2YctB57mTPbHwTvH9bTMlXHJDBI/ASDQypCp0AEjph8r4MvT8Rkr4vinRgrCNlIhOUyJaUiJekxLGWlPC9DZKzsK/OgCJ+AGQ+JwBiQLC3as7ZEx4hrufhhmhgamouZWIPUJCJRIKiHwjJNhpSLRuB0mtf1lIKJSQAGkBSZniWsnDrdHVVlIXdgdKqKeAcARhpCdFILQItNDObulIR74XNVIi90mJIhSpkvKAKZHYjpJa/xqUkDatZEHJ2qN1u5XUdd0BEmU0lxELGDqLQ/xABY4PzzNSEuSaq0ZI1J4h4VoDOWS/xdtBUutfBRLdHhI8DEjquu4AifGCQFNPy9JraeZFhDg2fEkMJZGRD89na0j0HiFB96UdpJsPJd3uJIRAO0rWCS+ICYGPUGGybgzbMFmm4IBs7SUdcVzryu5iuZhxnksa9HUgUXnEfYBJQ0AFoPjDWtSgIOwTFEmpAkY2Wy7oNCi8peXir2C5lnueDeDZ3aTGBB6+QzvaTfgPsFzO/yMGHoboUx+Mg0TqKPB9DIB6QBotF5J9QqKAusOR2my5ug0J6naQ1PqDgIQNHrnxjkJS13UHSMIoFBw5j4RvGJb+ixPh+RFERGvp+Y2Q0D1C4hoJo5xvOZewTkNCoGUrWSe8MCZYnUxIG0ywwoQfBibrwu7STCLm+aEKuScwCLgJjdIhcq1JoAKPhI2csD1z4lyX2MwJ7zQnUrbDpNa/BiWUt6YE6YEcTOrCbqOk908p7Cf2azG8LgeeZ4tVuCyK63xwcnLLkvjT8QUFJfWxhgtAwhFgBGLMNI54TK2FT1JTEr+7dbPZ/POxe+LJNJm8G6Wzk/h6enJDT9bPmf+0XpjhaJ7laXZKJGpOFUF+dI/WVXwbsEfVrefTW3tK4Gi5mU7vb6T+ZZwPZ2lWLW2RzW31Z524eLm8+f4/AAAA//8DAHRmzourIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:14 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "13"
+          ],
+          "x-request-id": [
+            "2d5a085fceaa480cc610e2398a23940b"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749484932&engagement_id_cursor=4FFA5531047F07E36BC1B94931CF1746&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:15",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749528145&engagement_id_cursor=2F3ABE8E5A64DD5CEC89E45991D8DA1E&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SX30/jRhDH3++viPLA03HM7uzu7EZClX+sT5Varjqu7UNVRb7EhAhiU9vhWk73v3ftJBgCBiwIJG+25zuzP2Y/ntnv73q9fjxJ0nKYpBP3MKsex3EZ93uD3l+9787uFDds03Fl6VtOzOdWmVBx5nlBZI3SQjGFWlmLvP9+4VlOR2fJyssIEmJpWAy6+E7KBUFtnDPS0j7Js/nFTTvTBgyCWdrz5J95UpRJvtRoAqVcBMaNXMXITk6cvZzOkmGRjLJ0XFRKtZpBUUwnab2oMhueTPOiHObJxfl/dzzg1pxnSVG4p2I4yuZpeddexZjeZy6zMj4fNhP/Fk/Lu7NbTe88S90g5ZP1o9M4TZPzOju/2uNj7+PPRx9XabiRwKKM8ypqXGRpLfbqfUjGrdpqyFrJgct9UPsMvoAYAB80eb7hlKTjVhccoF47Gm6Mcl4shqpdjuyf90tc4Fpw/OmXP2zYMvKNhf2enqXZt7T3OZlll8lKH18muXN48r5WQeeFk92Td6f48b4dEt/3Q+Seto4Q9L3AIxCGG2CBChSAaIVEbg4S4kwJQfgIJLjVkDCQ3ShpHF4XE8YrTJpMPwGTygUHwuwGJs3GPoOTMLDMt4YoRKk0CRMi+TxkkeWgffJbOVEb5IQpqcnRig9yst3FhDpiQm9JCYfOlKB8jJJPv9mjLcCEXoASDDhaq5QX+dXpjiwGFEiLaIArH6GVEtosJQaQAdthSlRHStSbUqK6U8J2o5aoF4AEIk8YcP2VcUj4hMyXggVWSS/g4BO1QqI32XJp7i4mBh8uJWKrIWGA3ShpHF4ZE1VhwlgXTFSFiVzvx7cUk2Zjn8GJu37ISEtCTwbuOhK5Y6qVFxiSSvgcVSsnZoOcCOCu5drtYkKqGybX+regpFsxqSkRfDcoud7X50AS6pACE/iBAvLIGJ/5xHyfE7furbXjkrBBSFCAqOqV3GFIVEdI1FtCgrwzJKh35F6iXoISwZlnhft1BwFpLSL0mIdCeMYGnglbS4lkG6REghLGSP1wKcGtpoRBx4tJ4/C6nHCoDj3IDpxULmIg13+h28pJs7PPKifMA00+KC/iyEGEkQ55xHREWiJfL6wNKHyToEgiJ+E73XNRN06u9W+BCYfOmOD6tXVbey56PiRgtRChRYikkcRJRVJ4NnTtl+IIdn0nGkhws5BohozRDkOyIz3XEhLqDgnuSC15cs/V+7sS9tPk33J4UQWe54ssnJblRTE4OLjCNP66f8JdUTH7Bk5AMCkARqDGaMRIxjxJ4CsZzuIPV260pDjbdyueTNPJh1E2O4gvpgeX/KBZZ/FTk5jhaJ4XWX7ISLg+SmqgvVu0ruyPAbtXT72YXiWHDPaWh+nw9kHqn8bFcJbldWrLfJ7UH68dFxX43Y//AQAA//8DAPTCV8uuIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:15 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "c500ed506f900766e0c0e209bc8bb6c9"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749528145&engagement_id_cursor=2F3ABE8E5A64DD5CEC89E45991D8DA1E&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:15",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749585807&engagement_id_cursor=0E844DE30F5957276F54AED7A76230E7&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+yXyW7jRhCG7/MUgg4+jcfVa3ULMIIm2T0IkHiCOMshCASO1JYFW6RDUp7Eg3n3kNTmjbIJSx4J8I1g/dXV28f6+fVdp9ONRz4p+j4ZlQ+T6nEYF3G30+v81flaxkvFrdh4WEW6YcSByihiVmrrhGXGWA2E0DBAwpnpvp9lFuPBhV9kaY6CzwOzorP3KCUlTGnJFMN5fJSl06vbcaI0aAZ6Hs/8P1OfFz6baxQCIvJSIZWYa9KzszJejCe+n/tBmgzzSskWM8jz8SipF1Wk/bNxlhf9zF9d/vcgA+7MeeLzvHzK+4N0mhQP49UY48fCRVrEl/3VxL/E4+JBLQIL+WWalFWK5ycMzuMk8Zf1+fxsT0/Nxx9PPi4O4tYR5kWcVcPGeZrUYlPvhB82aquatZICFYcgDwn5DaAHtCfYI0k+GTam8B5j9y5HWaOY5rNSdcqnX+zJ45py5Fpx+umnP2zUUPrWyn5PLpL0S9L51U/Sa7/Qx9c+KxOev7PVqNO81D1y9qXi2/tmUJwUPOJBSGQQRRolWkdDpwQCMHBaN4IitgmK0JQTJdhaUMROg4K8HSdL/etjwnogW2NC4SlMTuyfO0DJcl9fAAlEoXUqdJYa5ygq1IEzIYkCQOeku//BWEEitwiJAqymQnAtJHKnIZEtIZHfExJCW0NC5H5AIjcAiQsRIgvSAKeScgk2Ch04xpEYSkA0QqK2B4mijIBWZKnZT8vF2lGySnhlTFRluTi2wUTVlmtPeslqY1/AidbScGaJsOBoZAKmkQcRGKMQJcfmZqK3yAmhRBDGONlnxyXbYbLUvz4lpeMirSkhuCc/JsuNfQEl0pFAkkBpJrUquwgpLzIEkWNOBdSGjZRI2DIlVHO5vpvsuOVqSYn8rpS07yXk/tXY0V4iNwAJ4aCiwKGTkYkw1Eo650LQVIXcCrz/vVhBQrYICaO0bGlErW8lb5ZrI5gQWlkuIlpgUqWwnlB70kw24rkktUY7w5UwzBmnozCklnIOTBs0GDSCQrcJiuJAKX2im7x5ro1hsvrNeDYmXO5HN9mE5XKWhCwIArQYWAOl1YksBKiMklzoyDZCwrYNSflfJNZC8ma5NgeJbA8J3Q9INmG5Qh4EHBnSwEVIhUHnUBpNTOm+AME1QsK3CIkUIAVqgmsh4TsNCQHejpJVwitjImvLRdtgImvL9WQv2RnLxZ8JSufvSthN/L9F/6oaeZrNjuG8KK7y3tHRDUviz4dnFBTqQw1nwIngAAOQQ6b5QMTUe/iMmpL4w01ZzecXh+WSR+Nk9GGQTo7iq/HRNT1aLTT/YXUy/cE0y9PsmCDX5f1HRg/uALuIP8XsQT31fHzjjwkczG/T8d2b1D2P8/4kzeqzLbKpr18uE2fb9u7b/wAAAP//AwCzxpxdsSAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:15 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "11"
+          ],
+          "x-request-id": [
+            "03d628ae29a2b80ea6294e6d18f396ae"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749585807&engagement_id_cursor=0E844DE30F5957276F54AED7A76230E7&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:16",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749657732&engagement_id_cursor=C4BB47372BFD725A7FF76A91AC98070F&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SXzW7bOhCF9/cpjKxbYPg3Q3pHSmRRoE2Km7RddGEIsZIaTaTWklsUxX33S9lx7DaREyFRLcMbWXNmhiL54ZC//hmNjrLLvKgneXEZH66bx2lWZ0ej8ejT6FeMR8VWbDZtIkfcgWYisSaRNk1ZSDmBtwGYQnIB2dGLVWY9O/+Sr7OMJFQ3gVXT1XtC5Exog0ILuolfzsvF1+040waMAHMTn+ffFnlV5/MbjSbQygAA47SuUV5cxHg9u84nVX5eFtOqUeJ6BFU1uyyWH1WXk4vZvKon8/zr1c87GfDbmK/zqopP1eS8XBT13XhTY3ZfuC7r7GqyGfiPbFbf6UXrCboqi9ikfrT+/HNWFPnVcnXe+tNT++r18av1MmwtYFVn86ZqVpXFUmyX85BPW7VNy9WiA1cvAV8ydsZwDHzM9T1JeTFtTRFjKf7YGrFHvahWrZYpJ+/88f2aWHmpOD1588GnLa23vux98aUofxSjf/Pr8nu+1mff83lMePTENkUXVZTds/BR8d+LdkqkT1ASqeCEtIanCdMhCOSKEqMIXSsl2CMlqABxS3OIlGBHSnCflAjZmRJhDoQSfA5K4p5mKUuVMsamiU/SYDQjHjD+lR5bKaEeKYnVuTZxHDspEYOmhIHohskm4e9ywqHhBKgDJ02KGCs4EE42M/sEUKxEDgm3KY+O4uNOjmcvCsoETA1B2g6K7hcUATLa2U5Q1KBBIezGya1+H5hw1hkTQQ9hcuw/DoCS23l9AiTAKKSOuFXcKSIZtHTWy8RZ4xJMZSskpkdI9LJAPHUd8pmrIyS4V0i6e4l48GYyDEjwGSCxSeLidYTidYT7xlOYgEAy/uJuVr4VEoL+IDHAJGcK6ZCdhAF1o2ST8Dcx4WewxITxR2OySolHrgevJsPAZDOxT+BEkLRaOwcanBaAVsvoIo6E8tan7E9b3XDC+uNEGy05oZBmJyfDNhMN3TC51e+Dkg5msqZEHsiJ63ZenwAJ5yGVTlqrwCsruEzj3cSSYkElNrCkFRLes5nEEmL3iYsGDQl29BLcp5UI2R0S9hAkJ+/88QAowWewEimd0xzIM4Yi+MClAuVYsE6pYFC1UiJ6pIRLqUHE7jspEYOmhEFHL9kk9MbJ/wAAAP//1NfdaoMwFADg+z3F6IV3NicxJp6BFHH2LYakLm1lVCXRMoS9+9RuSstYkTHW3eY/OecLyddJz3snIOY44YMT8U+cTCf7AyjJY8IoUoiFjFkkZRSjFJJFgq2DxFtfPj8nKPw3oQifMwyC76Hwm4Yi/XlOxvZ/wYTibCbe5bf1VpmMB3tNyf1T33BR6Nc6rfqBG3OKwr6uK/tASOsVauNuGQQSXYQtcOpzgAzEs4c88xXTGjYSGVXLtptN2xe32/EuL3bLrDwQVeXkyMi0T7uaApNmjbGlCankKKETgs6Z1s/6a2CdYek2b3VIwflIpvA8kRZ7ZdNDaYbQ1qbRQ+HY8XS53L29AwAA//8DADQg/p+wIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:16 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "b86577c087cf3b7c9d5c2957557df4c3"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749657732&engagement_id_cursor=C4BB47372BFD725A7FF76A91AC98070F&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:17",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749700939&engagement_id_cursor=EDE21910C67C2A77AC97672A62F8E3F9&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TX3W/bNhAA8Pf9FUaeW+B4x0+/kRRZDNjSYdnHQx8MIVYyo4nUWXKLodj/PsqJrbSJnAieEuVN8N2RFOUfePz6w2x2kl8WZbMoysv0cN0+LvMmP5nNZx9mX1M8ZdyJrZZt5CQDQGYoy4LWVkgDwjrrWeSeK5GF7OTNTWWzOv9Y7KoMV0rcBm4mvfldSYmMtJGkSd3GL9fV5tPdONMGDIG5ja+LvzdF3RTr2xytwCA3XDKJu5zq4iLFm9V1saiL86pc1m2m3K2grleX5falmmpxsVrXzWJdfLr6514FfLPm66Ku01O9OK82ZXM/3o6xeijcVE1+tegW/iVfNfdXt9ugq6pMkzRPzj//Ky/L4mr7dX4OZ2f23Y+n73af4c4HrJt83Y6a11W5TbbbfSiWvbntlNtMBBRvQb5l+BvwOeAcxQNFRbnsLaE5wXd/jTRHs6lvptqWnIY/H05JA28Tzt7/9Ef3D/tu5jsv9nv5say+lLNfi+vqc7HLzz8X61Tw5H1tB93UKe2B754y/n3Tj8SCFs4SAoDXATIZnLKGc6eERRH7kcgRkQhCrYGhOIiEJo2EgRqmpCt4Zia6ZQJ6CBPdMhHiMSbvfwmnE3DS7ewRUJiESAKzGIiMd8ELG9OxAhDRR4rUC0WNCIVraRiSZgehiElDUWaYk33+SzBBGsyE4ythst/YI5Q45QJ3MkYrKHgUqdtiEYADWsmIm14lekwlnBQIYdRBJRPvueQwJfv8l1BCbLASUq+k55LHI6HAnAMnJLOo0g1FKzRCEFnLISoee5GYEZFISUkh8MM9F580Esb4MCVdwfMyYdgyYXIAk7aEz9mjV5OJHCbdzh4BxbhgA49cokPlJddeMM/RG+IWrOu9nGgYGYrRUtBBKGrSUDQOc7LPfwkmxAcySVcT+UqY7Df2mJtJUDrT3DPynImI5CO3FL2kYDM8oISNqESBNIkKHD5O9KSVSD1MyT7/JZR014ynK3n0MJlIz6X/ByQx6nRkyKg8j1HwwDMmY6Co0aW2y/UiwdGQMABgnKGiw0eJmDQSxtgwJV3BMzORw3su2fZc8OjVZCKHSbezR11OSKJhXoWkRHEKXgulIgnhsowU9kKh0aCAMQKRmzTUa+65zDAn+/yRmPwHAAD//9SXW0vDMBTH3/0Usoe+dTm5mBihSLH2W0jJarYVWVuSVqTgd/e0k5YJVooM52uu5/bL/2QWE86XY/K1NC5UTca4/kZNVPyQAgOF3ZaME85UrFOKgCQq4Un6+C0k4myQoJqgLVRoNQ8JhYumRKpllIzr/4KSZT2X7Hsuof+JmIyB/QmT66d+4aq0b01W9we37piFfdPU/o6QjpdmE24Z3CodatgC/lIEQA7ymWuR3xhmLWwUPu9m3eFt1r+E6PGuKHfrvDoQUxfklZHJT38/JSbLW+crF1GFlS8ElSw4wXWanyc2GEz3RWcjCsFnMUWnhbTaG58dKjektnGtHQbHjUe6rt4/AAAA//8DAC0RgxOxIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:17 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "15"
+          ],
+          "x-request-id": [
+            "d11d453410659470ee76f44a70976794"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749700939&engagement_id_cursor=EDE21910C67C2A77AC97672A62F8E3F9&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:17",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749744162&engagement_id_cursor=17ACF0207F236AD327A9F1BDDD7D3DFE&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+yX227bRhCG7/MUgi58FUezM3sUYBRLchkUaO2gTtuLohAYiZYFW6RLUk7rIO/epY4+STZhq5aA6org/LOHWX6af7+9a7XayTDNql6aDf3DuH4cJFXSbnVbf7S++bhX3IqNBnWkrWJwBhGtFpIIAy4iqZVAK3RIlkz7/SyzGvUv0kWW4UqLeWA26ey9khIZaSNJk5rHh0U+ubodZ9qAITDzeJH+NUnLKi3mGq0YMKkEMI1srsnPzny8Go3TXpn282xQ1kparKAsR8Nsuqkq752NirLqFenV5T8PMuDOmsdpWfqnstfPJ1n1MF6PMXosXOVVctlbLfxrMqoezMVgUaHLPPOzVM9P6J8nWZZeTs/nZ3d6aj/+ePxxcRC3jrCskqIeNinzbCq200qkg7Xaes6pEgHFIchDhp8RuoBdxh5JSrPB2hTqCnnv4/BzVJNyNtU05eSTO35c40eeKk5PfvrNRWumvrWzX7OLLP+atX5Jx/l1utAn12nhE55f2XrUSel1j5y9V3x/vx4UUsCNNJqF5BFxGIEDRaSkcs6/vV+LFShym6CgQAMkxUZQ5E6DonQzTpb6t8AERWNMOD2FybH7fQcoWdb1BZAYCbGSOsYwNkpQCCLAgJHVBgP/tYu1kKhtQqL8CILDPkMiVTNIlvq3gISa9xLS+wHJsq4vgCRWEUpu/Y8JFjhwIhQoYxOG1tk4vP93sYJEbxESzqUEg0pthITvNCR+F00tF38DTOgzNLVcsxRvue7/g+4oJqvCvoQTMiDAKsXJhmRMFMcYRAoD6a8mENm1nJgtc4IkGW3kROw0J3vhuBaUIG9MCcf9oOQ1HJcNyHHp2QBpLEEcBTwwkbRGk43BxusgMbBFSMgopbQQm5vJjjsu0QySpf4tICFqDMnTjuvkkzveAUqWhX3JvURx5hg4izbgFhSSsQFI5iyDWIRrW4lh26MEmeDcHwuyjZTQTlOyN5aLYf3RM92AkzpFeLr2hJNX8VwyZk7FPNTobChJSGkEMMYjZo0xAawFBbcJiiK/FKE3g7Lbnks3bCf6bdrJDJNG7aRO4V2xL+1Ev0I7kQyCUKGOSMQ80L6lOAwYDwMWRmGAci0ltGVKlFpp/jddW6aEQ2NKuNiPm8lreK4w5IQCuXTaBFZa1AZ1bKLIRaFzMV8LCd8iJEoQSSTYa8+1dIzP9VzLhP8YE1nfTZhpgomsMcH7PmNHMVkV9ilOWn/WwnaW/l31ruqRJ8XsFM6r6qrsdjo3lCVfDs8QtDKHBs6A++sBQB/kgAzviwTTFL54n8WSDzd+trS8OPRbHo6y4Yd+Pu4kV6PONXZWGy1/WB1Mrz8pyrw4YoobTSDIHNzhdRF/CtmD6dLL0U16xOBg/jEd3f2Q2udJ2RvnxfRoq2KSTl8uE2dO9d33fwEAAP//AwDyNwT3sSAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:17 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "01fc653132f502e297b0cae695e8dd40"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749744162&engagement_id_cursor=17ACF0207F236AD327A9F1BDDD7D3DFE&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:18",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749830539&engagement_id_cursor=CC4325246E89BA6A28928F9DDEDCEEF4&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+yX227bRhCG7/MUgi58FcezO3sUYBRLcjco0DpFnbYXRSEwEi0LtkiXpJzUQd69S1IHOzZlE45iCa2kC0Lzz84e+HF+fn7V6/XjSZKWwySd+ItZdTmOy7jfG/T+7H32ca+4FZuOq0ifUiYMUMdBGBVw5SRS7rghxoSUi6D/usksp6OLZJmlmdR8EWiKNv9LIShBpQUqlIv4JM/mV7fjRGnQCHoRz5O/50lRJvlCoyShkikQEsRSk52d+Xg5nSXDIhll6biolASWUyiK6SStV1Vmw7NpXpTDPLm6/OdeCtyZ9CwpCn9VDEfZPC3vx6sxpg+Fy6yML4frmX+Mp+W9Woos1JdZ6ouUT9aPzuM0TS7r4/nZnp6atz+evF2ew60TLMo4r0aNiyytxabeh2Tcqq1KNqcOlB+COCT4nogB0AHDB5KSdNyawvzvq3vD1yjnRVOqTnn3iz15WONHrhWn73763UYtpW+t7Lf0Is0+pr1fk1l2nSz18XWS+4Qnb2w16LzwsgcO3iu+vG7HBEhoImu4tcipcJpzwxkPWBTpMFKCt2IitosJESBWY+wlJkJ2w2SlfwlMOO2ICQ64fgyTE/vHDlCy2tdnUOIUMVYqy7R/fCvkqKmWAUEJJhARta2UyO1RgqiRAxeCbKSE7TQkhNBulKwTvi8mFCpMiOyASZXiu8meYLLe2GdwEqANIOBEOQ2MW+lbirGWo/Kmh0XatXKitsmJlMgoyM3dRO40Jwq6YbLSvwQlyDpS4pvJ3ngueD4lyF1gwpA477pCp8KQSgQHPGJMO2m/fmCsKdHbpESgFoI90k12m5I9sVwNJYx0poSpPaHkW3guKa1yCARd5GSEioUCkAeR0AysRtFCiQLYIiUatSQcKf/fc22bE/YeGs+ln8xJk8IGhPyHPBc3gljKjENmFbdgQXpolJPeiLmItXkuBWS7nPgCoDZzstvdRJFumKz0L0EJPv3NpEnxnuvRbrIblKz29RmQgGSopP9EkWSGcYoarLIWjQFrNG+FhG4TEu49l39F2my51E5DsheWawkJ490hofsByTdxXJwZKhkJqDdbMkAVaQ6OMARKQ0FNKyS4PUgYlwKJJGozJDvuuKBjK1knfGdMWIUJ0C6YsPrNBPcDk/XGPoOTMHIMHUSMmEBax4QgoTVBYKnWkpuolRO2TU78l0g/1EZO+E5zInk3TFb6l6CEdGomNSUI+0HJal8fg6T3VyXsp8mncnhVDTzPm0M4L8urYnB0dINp/OHwjIKS+lDDGTDCGcAIxBg1G/GYJgl8kJqS+M2Nr5YUF4d+xZNpOnkzymZH8dX06JoerddZ/LA+l+FonhdZfkwk00qiRH5wB9Zl/DFeD+qpF9Ob5JjAweJeOr57H/XP42I4y/L6ZMt8ntR/rhKbZ8urL/8CAAD//wMAMrYLHq8gAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:18 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "ef0fd32e4e24e39f894f8992da1392cb"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749830539&engagement_id_cursor=CC4325246E89BA6A28928F9DDEDCEEF4&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:18",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749873735&engagement_id_cursor=CDF43F0D41AB7EF4661CEABBE29975AD&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9zXS2/bRhAA4Ht/heBzAuzO7OxDt31wgwKtU9R9HHIQBIt2hdhkKlIJiqD/vUtKlh1btEPYtMSeLHhmuNRyP3Hm6w+Tycn8Mi/qWV5cpg/XzcfFvJ6fTKaTD5OvKZ4y7sSWiyZyIjJnnM8MF07JzJHyjFkUkmvFvXb+5M2msl6ef8xvqozQjLaBzaKb/yspgaM2EjWqbfxyVa4/3Y1zbZhBZrbxVf73Oq/qfLXNSesKIhDpD/BtTnlxkeL18jqfVfl5WSyqJnN3B1W1vCzaL1WXs4vlqqpnq/zT1T8PKtg393ydV1X6VM3Oy3VRP4w311juC9dlPb+a3d74l/myfrCWvLm9q7JIi9TfnX/+17wo8qv26fycnZ3Zdz+evrt5DHceYFXPV81V51VZtMm23Yd80ZnbLNlmAgN6y+RbLn5jYspgCnxPUV4sOktwCvLe0Uhr1Otqs1Rbcpr9uT8lXbhNOHv/0x9Z6Fj5zhf7vfhYlF+Kya/5dfk5v8mff85XqeC797W56LpKaXuee8r49003Ep3OrPRRRSKnIB1uiy4IIYMgwbyxnUjkcEiIC0wLaEGPIsGjRsIZ9lNyW/DKTHTDhKgPk1QipqjHweR2Y5/hRILmkmQGwmmIllRwCslqCBC0991O1JBOwCAZJcb8MlGyH5Nd/usrwSkzvZUAjUPJbl+fgQRTj0XATDQ6SKelCIbzCFbF1HNlPHYi0QMjSUwQR4xkLB1Xi4T3f5UAewrJ+1+y0yNQ8hItl49RkXcSvGTOgInolBDWeOSesww7lZgBlSgwpBDV40qOveUSfVsucRAnHJqWq5eTpgSnZEbi5HZnnwFFIGOpgUq/38LboISMAIq4iem4BzD3p7QdFM6GhJIGIyLOHu+55FFDGUnPtWGCrDcTcf9o/I97LgaWS6uZlSKCsVwxChkxDCQsjybrRMKHRUIpj9GIkcieSORBkcj+SGAcSOQLINFZ0NIZa5VSPBDqgBqCypzTHELsRgLDIZHI0suMmycGEzhqJMb0Q7LLf2Uksm24er1JZIvkyYbrOJDs9vVZ7ZYjyJz2wnpGSsvAMM0qxLwVVmnRiQSHRCIYk0rtcvYjoaNGonqOJepAU0mLBLA3ElTjQKJeYCaJRigfmUSLKvB0wiV6Aht1GlDSrBI7kYgBkYBJQxLjo0YiqR+SXf5BkOj+SPBASP4DAAD//5RWyQqDMBC99yuKh9w0k7g1hdAvKRLTuCAuJLEUof/eaBfx1PY6++PNG+bfdyv+UST78xzodepms2EuPOonCZW1gzliPIWdyP2CwiFlPoMCIhK7ay4huYQskrGgSkGeMkpEMLluyjS+Q1zWXRnIvsViqPGV4hWnOa28ZHLUptecpBFjJHEKQxuxvv3f9IqW0U09KU4AvXaJb/fIq4TJ2l4vzFo9qsX4SZytBHb3BwAAAP//AwCK/ibBqSAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:18 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "135f152b87fd626e4c80d1e32a2c0cfd"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749873735&engagement_id_cursor=CDF43F0D41AB7EF4661CEABBE29975AD&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:19",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749916948&engagement_id_cursor=F947CF063A37D113863C52AF8AD7807F&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SX32/bNhDH3/tXGH7IU9MceSSPNBAM+lkM2NJh6baHYTBUm3GMxlImyWmXov/7KNmx80tOBNeJ/CbovscT7/jRHb+96fX6ycSm5dCmE/cwqx7HSZn0e4Pe371vzu4Ut2zTcWXph1x6xJEpDAIvAhawWJHwYxmSFxnO+m8XnuV09NneeBmhmVwaFkEX70kpzlAbhRppaZ/k2fzytp1pAwbBLO25/Xdui9LmS40mprSWSMIQLjXZ2Zmzl9OZHRZ2lKXjolLeWJOimE7SelNlNjyb5kU5zO3lxX8PPODON89sUbinYjjK5mn50F6tMX3MXGZlcjFcf/iXZFo+iMWAL+UXWeqilM93GJ0naWov6vr8Gp2eeu9/Pnl/U4hbJSzKJK+WTYosrcVenQk7btRWMWslBy4PQR0y8ZHDAPhA8kecbDpudBEDFPcOh4tRzotFqNrlw2/RyeMat3KtOP3wy59R2BD61s7+SD+n2Ze097udZVf2Rp9c2dw5PD+z1arzwukeqb1TfH/bDIrxHCkQgOaGhcgkjxiGviKfuPIxiBtBUTsExYBUWjHBNoIiOw0KyXacrPQvjwkOQLXG5ME/tKuYrBK7BSUQejyUTMXG9yEU4FHsUKFQcy9ETX4jJbRbSgiUJtpIieo0JaolJeo1KWHtmwmjPaFE/QBKlFAiENrjJIRR1TCFXACRAe4FEZhGSvTuKHHzluaAXG3uJV0fuqgdJmuHl+REfoR66OLy2ZwsXMQttJo4OYn+6gAm68RuwYmGyMgoVFzFiExrpUzoBUZpqWOPeV4jJ2aHnEhuQBmmN3PS7W5CLTGh16REPL+bLFxwIO//QrvaTegHUMJZACFFQhp3voVi7kZAbgbjgRdG2iPVRAmHXVIiOUpS3OwxJUq1o2SlfxVKdHtKxJ5QskrsFpQYiSaWJLRBTl4IAZcYUxxjFKHvB3EjJWx3lGjGpZD4VC/p+szF2mGydnhhTkTFCcM2nIi94mSd2S1AAYgDQuRopBu4EHQMQqmQRxgYDGJoBIXvEBTQ6FYwiBtB6XY7IdFy6BKviAmn1pgIth9Xk1Vet4BEAovc31uxSPAYtVAUALrmIhAi5oFshAR3CInrJlK5EXCfbyZKtpy55CtCgu17Ceo96SWrxG5BiQg5J2ACAqYEYBR7vh+hlFVLESrCRkrEDikhBE4S1OabCe80Jca0o2Slf2FK9ADYQLZqJbqm5P6ltaOtZJXXpyDp/VMJ+6n9Wg4vq4Xn+aII52V5WQyOjq4xTT4dnnHQZA4NnIFgUgCMQI3RiJFMuLXwiQxnybtrF80Wnw/djifTdPJulM2Oksvp0RU/Wu+z+Gldl+FonhdZfsxIGENCMjq4A+uN/SleD+pPL6bX9pjBwfIsHd89R/3zpBjOsryubJnPbf1y5bgYU998/x8AAP//AwBK9x6WsSAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:19 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "9c0c79dd41148425e0d036e356506bfc"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749916948&engagement_id_cursor=F947CF063A37D113863C52AF8AD7807F&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:19",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749974517&engagement_id_cursor=4D2270140C16403EFABBE3558F0446E3&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXX2/bNhAA8Pd9CiPPLXD8c8ej30hRKgZs6bB020MfDCNWUqOJ1Flyi6HYdx9lO0qWWG4ER7GdJyF3R8qkf+bx+0+j0dn0Oi/qSV5cx4fb5nE2radno/Ho4+h7jMeMB7H5rImcScsGDJBOpci8RIOKyEhEdFnCSp+9WVfW88vP+V2V1SxxE1hPuv6/IZJCsSXFymzi14ty+eVhXLAFq8Bu4ov872Ve1flik8NGMFnWaCyLTU55dRXj9fw2n1T5ZVnMqiZT371BVc2vi9WHqsvJ1XxR1ZNF/uXmnycV8L93vs2rKj5Vk8tyWdRP480Y823huqynN5P7F/82nddP5jJqk31TFnGS+tn5l5+mRZHfrHbn1/Tiwr37+fzd3TY82MCqni6aUadVWayS3Wod8llnbjPletNB4lugtwI/AI9BjgVsKcqLWWeJGkv16KsR56iX1XqqVcl5+tf2lDjwKuHi/S9/pqFj5gcf7I/ic1F+K0a/57fl1/wuf/o1X8SCZ69rM+iyimlb9j1m/PumG4lJHKTag3JkMm08eyC0IqAFn4lEdiKhIZEwSYN40kgI+yFp8w+CBPsjgdNA0q7rHkislj5FE3Qmg7AEAiFTBJ6C1oGIOpGY4ZDYeLyhMkrvRqKOGokA7qfkvuB1mQjZMFG2B5OmRI+lOQ0m9wu7hxNGn4WUU+W1ZwHxR9w4xxyUkyiN7+64eEgnRiMraMfY7oSO2okx/Zi0+YdQgn0Ok7US8bjPOFIl7bru03EhGocENkIJoKzNOJPsbSY4Qe+TTiR2WCQE8bK0+zA5biTUEwkdDokag+iNBPg0kNALIAmgZTxBMhESSLyj4CSBsU5gyknqOq8lCgZEEvstq+Mf7kSCR41ECNmz42oLXpkJrS4m3IcJrc6SE7mY3C/sHk4oMVkEkcVvp0691zK44FOHITZfzqVppxMxqBMNWvzoZmKO2glDPyZt/iGUKOqpRI3x8aX1SJW067oHEiVNlgF7SCgRmGFCIigJXnMis3jIdCKRQyLRmlkrbXci4aNGciod1wqJ1v2RiNNA8hIdF+hUULAQHLCwAYmZEpto4SU677tPEjUYEgmND6UJ1U4k6qiRiPZS9dyOqy14XSYSGiZgezBpSiKTU+m42oXd5zAJGXjBCaANASEJwgnppAppIg0b2+lED+qEJVolT/lmYrAfkzb/EEqk6q1E8Y+UvP8tPX95Jv8BAAD//yI5m8ADllAuUYgFKVTKS60oiS8AGVxaBImFjJKSgmIrff0q47zEJN00IwNgvtC1NEgD9gqAXQODZAOzFGNLk2TTRKPUVIMkc0sjw0S9KqBtqcXZukAfp2fmpesl5+fqJxZk6pcZ6SP8WWyPiJj45NKi4vwiW0NzUwMDQ3NzE2M1lNwKkyeUYdXATi/OrEq1NTRQgyYmW9SEpJSRWByfm18EjtqSotJUsCBcI6Rw4aoFAAAA//8DALVKyhmrIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:19 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "d1cd8be662b39a45c39dc80e5ba79d77"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1749974517&engagement_id_cursor=4D2270140C16403EFABBE3558F0446E3&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:20",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1750017743&engagement_id_cursor=3DF0B18C059DD50CD1A12A23DEC27879&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+zXwW7bOBAG4Ps+hZFzCwyH5AzpGyVSxQLbpGi6u4ceDCNWskYTqWvJLYqi77607MjZxkoiOE4UoAcDgucfUqb0WdT330ajo+lFXtSTvLiIB1erw9m0nh6NxqOPo++xHhM3avPZqnKkMmRIJFjBWcoSnQgqTYUSlOkskf7o1bqznp99yq+7rDJSbwrrSdffMxEKaSxJI3lTv1iUy88368JYsHHCTX2R/7vMqzpfbDKGERRqKUiq60x5fh7r9fwqn1T5WVnMqlWyPYOqml8UzY+qy8n5fFHVk0X++fLbrQ743zlf5VUVj6rJWbks6tv11RjzXeW6rKeXk+2Jf53O61tzEW3Sl2URJ6kfnD/7Z1oU+WVzdd6G01P35vfjN9eX4cYFrOrpYjXqtCqLJuyadchnndnVlE0SAfVroNdCf0AYA47R7GjKi1lnixxL9dOtEeeol9V6qqbl5F043p2JIzeJ05M//gq+Y+obv+zP4lNRfi1G7/Or8kt+nZ9+yRex4cELuxp0WcXYjgsfEz9edSsJPvVZkglJIDLh2ekAkBgrpUl1ArJTCR1QiUWNQGzEnUrUoJUIIfsx2TY8pRP6AI0ToR7sZN2ixsD3OTkOfw+AyXZh93Bi08QYCeTBeSVVSMnKYDQarRKIgDqd8IGdoGDNdzqxg3bSIn8gkzb/HEqk7KlEjvW9T5NhKGnXdQ8k2ht27LVWIrhMG5dqlyBm4IPTLG0nEnNgJFJvx9iNRMCglRD3U9Lmn0OJwt5K1M/3xkCVtOu6j5J4OzKTTl1qJYJThmVKpMgYReC7X0zs4ZQIUEYxxLejl7zlAt1PybbhiZmoFRNNfZio1ZZLiZfBZLuw+2y5UKeBM2UlyUCSLTuwIDAIQQJt56uJggM6EfEU2BLf/TTRg3bC1I9Jm396JXIsej1MGiVoXoaSdl33QOKFpcAWjReYBXToWJJx2qoUE2c6t1ztH/2hHiaGTfsnsBsJDRoJ9URCz4rE9EfyQt5L6BGQKEc+eEsZ6MQrY1M2xttgM7beAHMnEjwcEgSlFDLcg+TXjutxmJiGCfdhElt03Kfdx+TkXTgegJNH2XJhKgClCZg5Mkn8SMdOJEL5NGOUaScUeUgopA0CoL0TysC3XNzPSZs/GJP/AAAA///Ul99KwzAUxu99CtlF77qc9CRpMijS1vkWUrIu28pYW5JWpOC723W6McFpEXHe5v/J+X5851zABEeVXHJoTD4WGlfqJsd//QEkkqNI5T2PU0iQJ3EqH1DhnMeCJill808hYb8JiaQBIAaX3SS8akjESDMRf+klqMZD8l9Kru86ye3jfuGkNM9NVu8Pbu0hCZumqd2MkA5LvfBXvTpD5StYAaOcAeQglqhYznVgDCz69oXqadffZtzW7yNeF+V6mlc7ouuCPAXkFKe7O+Uly1vrKhvRkAMIClR5Z7C+z3/Fqzc83RWdiSh4b1qKznU02WiX7So7ZLaxrRkGjxsPBnzz8goAAP//AwA2tmBTrSAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:20 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "aa087ceca84dd3728ef959294227944a"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1750017743&engagement_id_cursor=3DF0B18C059DD50CD1A12A23DEC27879&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:21",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1750061019&engagement_id_cursor=8536C8D5AC0B35BAC8F393E5A61BC14E&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+yXS2/bRhDH7/kUgg4+xdHse1eAUZD7CAq0TlGn7aEoBEZay4It0iUpp3WQ794l9fJLkglbNg30JILzn53l7P40M9/edTrdZOzTcuDTcXiYVo+jpEy6nX7nz863YA+KG7bJqLJ0GRgaM6QEppGxnBmpMQWrqaAgaBx13889y8nw3C+9FJWULQzzoPP3gnOMiFScSCIW9nGezS5v2pFUoAiohT33f898Ufp8oZECY8o4gApLLTTZ6Wmwl5OpHxR+mKWjolLS5Q6KYjJO648qs8HpJC/KQe4vL/695wG39jz1RRGeisEwm6XlfXu1xuQhc5mVycVgvfGvyaS8FwvBMkMXWRqilI93GJ4laeov6vP52Z6cRB9/PP64PIgbR1iUSV4tmxRZWoujOhN+tFFbxayVGDA7BH6I+GeE+4D7jDzg5NPRRhfaJ/LO5QgxylkxD1W7fPrFHj+sCSvXipNPP/1uzYbQN77st/Q8zb6mnV/9NLvyS31y5fPg8PjMVqvOiqB74OyD4vv7zaBwJJQhjghtMYmkdeGKuwALIdbGgm0Ghe8RFEaIrH7VVlB4q0ERvBknK/3LY0L6oBpjgtkuTI7tHy2gZJXXJ0BCI6cYlthowyJOHcLUWc6NoRhhh+/+YawhEXuEhCoAorDaXk3aDQlvCAl/TUgQaw4JehuQ8GeABIuYUOA8lBOkmUSRpDQiiiAGSgpnNkIi9wiJ4FIiBXx7Jfm/5XoeTHjVcmHcBBNeYQLibWDyLB0Xi2Vk45gghylWzhkhBGZxRBAxBtN4Iydqn5xIhimFHR0XazUnQjTDZKV/DUqIaEgJ6TP6RgaTVWKfQIlCMYlc5CxFTAjjrMVOSiUl14xJcreurihhsGdKGCVKbKWk5S1Xw2LCX7OW0EYt15wSeCOU8GeoJVQJxomIkQaIFXFhOLEaxSyiyDot76ZiTQnaIyVKMaYQkO2UiFZTgnDTngu/DicYKk4YacBJ5UL77O7U2lZO1pl9StMVYOCxdTi2mljOubPaWOdkjHWM8GZQ8B5BkZyCpEG1FRSEWk2KpM1AWelfnhPSXx/0ozmhO7uudswmq7w+hRKqLXKaW2kY1zrSwmguNXciXHWlNjddZM+UVOMP204JbjUlvOFswl9nNplTsu6uH00J2VlN2kEJf4bRxGijpRGWUBQxBsbpMKzY0HupyNqQmI2U0P1RQhBVDHHAaislpNWQIIBmlKwdXhIT8Rnqpgse33TNXUifkrfSdK0yuwuUzl+VsJv6f8rBZbXyLJ8fw1lZXhb9Xu+apMmXw1MMUqhDBadAEaMAQ+AjouiQJdh7+CIURsmH6xDNF+eH4ZPHk3T8YZhNe8nlpHeFe+sPLX5Yn8xgOMuLLD9CgkHAhGFycAvYpX0Xswf11ovJtT9CcLC4TUe3b1L3LCkG0yyvz7bMZ75+uXKcp+3d9/8AAAD//wMA2bclt7QgAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:21 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "6c72ec89a228132d82a4b2067c08728a"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1750061019&engagement_id_cursor=8536C8D5AC0B35BAC8F393E5A61BC14E&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:21",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1750118523&engagement_id_cursor=DCDC8D7E341A550DFC91BEFA69AEE025&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SXXW/bNhSG7/srDF/kqm4Ov0kDwSBRZDFgS4dlHxfDYKg27RiJpUyS0y5F//so2bGSJkqiuY4tGDZknfeQEsmH7+GXN71eP565pBi5ZOYvFuXlJC7ifm/Y+6v3xce94k5sPikjfc4iwqwNBYqoxVRSTTSiFgKJmbZc9t+uMov5+MLdZikqGVsHVp2u7gvOMSJScSKJWMdnWbq8uhtHUoEioNbxzP2zdHnhsrVGCkwQQRQLyshak06nPl7MF26Uu3GaTPJSuXmCPJ/PkuqlinQ0nWd5Mcrc1eW/DzLg3jMvXJ77q3w0TpdJ8TBetjF/LFykRXw5qh/8UzwvHvQl6Fp9mSa+k+LF+vF5nCTuspqdn83ZWfD+x9P3t9NwZwLzIs7KVuM8TSpxUI2DmzRqyy4rJQbMBsAHSPwGMAQ8ROKRJJdMGlPIkKBvlobvo1jmq66qlA+/mNPHNb7lSnH24ac/TNTQ9Z03+z25SNJPSe9Xt0iv3a0+vnaZT3jxwJaNLnMve2TiveLr22ZKAiM5AUAiCP3KNBqUDYJIsZCC4SxspoTvmBICDLMOU8JZO0o2+n1QgnFrSrDoCCWbgd2CEhtyrv3CtcoohXBkIoo4DQUnQmGLgkZKxA4pIcSTyyV62kvIQVOCALfDpE54ZU5o5Sa8DSe05IR9u4UeKif1yG4BCkSIBUpRzEAGBIzGWCIVGcKtCnXAG0GRuwRFeE78p8t2IlraidiTnVSYEGiNCWXPYXJq/jwASsR3cBMhhQ4kCSUGHRlm/YkktIRIX/P4f6QZErVDSLCPe2w3jtVFSLpSc60gae8ltCsnk+9Sc2HwVRZlloNG4AuvQCvNpdUMh2HIbBMlHHZICS2/z1oJPWhKECbtMKkTXpkTWZ1NUBtOfAodYtoNM6kHdgtOtJYBtpRKSwMUIRsoGUiJIqsiRjgyjZygHXLCQUnOKFdPcoLgoEGRtB0nG/0+MKkLqBdjAqojdrIZ2C0wMTgKNfHrHrPIMsoM1tpGRhtksDAAjZjgHWMiWN1GJzHhoh0mG/0+MGH/AxPcEUw2A7uNmxCNvHtgZJQBz0gkGDdchFZTYUMVNmJCdocJBSmoEkx1+WyCALfDpE54XU4Qr6quNqeTMsVzIjvCST2yW4AihBEKYyBa4dAQAtr/RB6RKBKSPNgzalDoDkFBvujihOCnjyf8oEERLe1E7MdOVpgQ2RITcseBDvtwIl7qJr2/S2E/cZ+L0VXZ8DJbTcJ5UVzlw+PjG5LEHwdT7LdxNVAwBYoYBRgDn/iCbMxi7Bx89DSh+N2N783lFwP/xrN5Mns3ThfH8dX8+Bof1++Z/1DPy2i8zPI0O0GCARIcMXl0D9bb+HO8HlWPns9v3AmCo/VaOrm/jvrncT5apFk1s0W2dNXNTeJqb3nz9T8AAAD//wMAk2OG+bMgAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:21 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "403636285fe99d53f919dfc6a21c6c37"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1750118523&engagement_id_cursor=DCDC8D7E341A550DFC91BEFA69AEE025&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:22",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1750176158&engagement_id_cursor=77E792203C92BE330CE33DFB9DD78302&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+TXUW/bNhAA4Pf9CiPPLXA8kkdSb5RIFgO2dFi67aEPhhErmdFE6iy5xVDsv49SbDlLLDeCYcfCABsQzDuRPunDkd9+mEwuZrd5UU/z4jZe3DeX81k9u5gkk4+Tb3E8RjwaW8ybkQsfGLMabZqqzIrMZDJoRoa40l5nkF68ecisF9ef8k2WEZrkeuBh0offFREyrmO25mo9frssV58fjzNtwHAw6/Fl/tcqr+p8uY7RCgUIkBwV5+uY8uYmjteL+3xa5ddlMa+aSNqsoKoWt0X7p+pyerNYVvV0mX+++/tZBvxnzfd5VcWranpdror6+Xhzj8Wu4bqsZ3fT7cK/zhb189VtlndXFnGS+sXx13/OiiK/a5/Oz/7qyr778fLd5jE8eoBVPVs2d51VZdEG27YO+bw3tpmyjURA+RboLVMfGCWAiZA7kvJi3pvCE8mevBpxjnpVPUzVplz6P3aHxBu3AVfvf/rdu56ZH/2x34pPRfm1mPya35df8k387Eu+jAkvrmtz01UVw3Y89xjxz5t+JOSMsUwx4ohWKe85oA3ICVITOM96kdARkXBlDKIRbC8SPGskxgxD0sWfFglCAiyROABJk8IT/l0k73/xl2egpCvsAUri+26D4qCDiX1EKfKWZMocyCAzlYVeJerISjiwLma3EnHWShQOU9LFn14JJiAGK2E0jlbS1fUAJDaTSpNO0VnjPFLcbIGSWukgyAevepHoIyKJy5CkNY4ZSbchfel+S74mEj0cCR9JK+kKe4ASoNRYA6lNVQgZxMbiyXGZoSJN3vleJeaISiRnCqQ0aq8SftZKGAzsJduEUzrRH6B1Il/u5CFFJALG0Uy2hT3AiXIBhCNAA8rHL49nE+kUD8xJHuTTUnROFBzTiTCcGNH+g4k8ayeKD2PSxZ9eSWwNbLASFONQ0tX1ACSMuELIpAdptZU+NRTfUMG9AkyZfNpXt0jYMZFwYxSAkCNGMootV4eEhiNh/6Mtl3ZGEglMOWNNM6G4m4LMSbRe+nhI6VWCR1QST0ZMihg76i2XGMZkm3BiJ6LZciEMcSKS9jMSJ9vKHgKFSe21MpAFFxDJkosHlYgmYokHENMLhR8TikIuRDyg7IVCZw1F0TAnXfxrMOGD2oloOpDEkTDpCnuAEsc4BBksshSJnEO0Fi1pE/dg5LKnpdgqEcdUYmQ8KhGavUrUWSsZy6arVSL4YCVCv4aSfwEAAP//tFbJCoMwEL33K4qH3DSTxCoRpF9SJKZxobiQpRSh/96obcVTT73O/nhvmPnn03W8zIFBrx62GOfCTq8sNNaOJsN4Yr0ow4qCvyohhwpi//QASEiujMfyJKhSUKacEhFNvpsyt9Ajrtu+juTQYTG2+E7xhtOcN2IK6bQZdE5Sr33CWcLQbls//l8Li5bRTTupnAB6iynfCylohCm6QS/UWu3UYvwmrif48HwBAAD//wMAKcccBq0gAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:22 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "055a29ee74a9a9dd518489dbab36711d"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1750176158&engagement_id_cursor=77E792203C92BE330CE33DFB9DD78302&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:22",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1750219363&engagement_id_cursor=D130F5FA21B266DD22AA2A6895A86DC2&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+zWW2/bNhQA4Pf+CsMPeWqaw9shaSAYKFEqBmzpsOzyMAyGajOOkVjKJDntUvS/j5JjKzc5FVwnNjD4RfA5h5RIfeL58qbX6ycTl5ZDl078xay6HCdl0u8Nen/1vvi4z7gTm46rSD8ODbMoJI8tEJCR8j+hwFARxAih7b9dVJbT0YVbVmmupLgNLCZd/C8RKWFKI1NM3sYneTa/uhsnSoNmoG/juftn7orS5bc5SlIBhAJjVC7HyM7OfLycztywcKMsHRdVJl/eQVFMJ2n9UGU2PJvmRTnM3dXlv48q4N49z1xR+KtiOMrmafk4Xo0xfSpcZmVyOWxu/FMyLR/NRcjyCS+z1M9SfnvB6DxJU3dZ78/P0empef/jyfvlRtzZwqJM8mrYpMjSOtnUK+HGrbnVnHUmBSoOAQ+J+g3UAOhAiCeKXDpuLeEDwR+8HH6Ocl4spqpLPvwSnTyd40euM04//PRHZFumvvNkv6cXafYp7f3qZtm1W+Yn1y73Bd++stWo88LnPbH3PuPr23YooVDEe6AxDaxS0rMBy6QKVci0ji22QsHtQeF+fAFMM7YWit5pKIp1c7LKf3kmbEBUZyac7AmT1cJuoAQDRTSjoQpIyEwUBxiRmCodBSHFIG4/TuQ2lWgifaZcr4TATjNB7MZklf8aTKjuzISJPWGyWtgNmMRUY0jQdzqMGxYbHiqOgmsVhhFFFrUyUVvsuqjQQiIj+911dTxNmoKXdUJo5QSwg5OqxHdd+jknJ9GfO8CkWdgNnCiBJtRWSWtVgDZUEFAZUsUsF5THD5eicaK36URrLUkzxtNOcKedKNqx6aKvqISyzkr4vpwmq4XdQAnjocQAaAgWKeOEWaOIjGIV8DBAYtqUKNimEomEMg3k/6brhZiw7kzYnhwm36PnskboOIxFFACRBjA0hATcv6Mhj9Aq3qqEbFGJIMhRCrVeyY73XNBRSVPwwkxwAHRAoAsTrGQJ3A8mzcJu4IQwoo2kVlgJRgcmoCRiaI2BMALx6IvROKFbdMIll14K6rVOdrvnkrIbk1X+ayihsrMS/vATuqs912phN1Ai0XBueKy0tbGhVKEVOiAxk6I6X2yrErZFJQIIAhK+/jSRO61kX1quWgnj3ZXAnij5Hj2XCKwURkYAMoaIy9hfgQGGAYJ/W9t7Lr5FJVL7GZAxtlbJjvdchHRj0hS8rBMKdc+FHZxUJXwAck+cNCv7HJTe31ViP3Wfy+FVNfI8X2zDeVleFYOjoxuWJh8PzygoqQ81nAEnggOMAMdM85FIqHPwUWpKknc3fjZXXBz6R55M08m7UTY7Sq6mR9f0qHnQ4odmZ4ajeV5k+TGRAqhEzfDgHthl/DmzB/WtF9Mbd0zg4PZtOr7/JvXPk2I4y/J6b8t87uo/V4WLXvXN1/8AAAD//wMAjoLrX7YgAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:22 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "8"
+          ],
+          "x-request-id": [
+            "4086ebd87e8c9ec655e28a9a1e995c69"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1750219363&engagement_id_cursor=D130F5FA21B266DD22AA2A6895A86DC2&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1750276936&engagement_id_cursor=5BD75A7E007F0E47FE000A036B605504&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+yXTW/jNhCG7/0VRs67wHD4MaRvFEUuCrTZotntHnowjFhJjU2krSXvolj0v5eSv9LEsiM4qhWgN0LzDoca6tHMfP9hNLqY3mZ5Ncny27i4r5ezaTW9GI1Hv4++R3tUPLDNZ7XlwlnlUxIqyISU40IQJEFZDz7FhBm6eLPyrObXn7ONlxFay7VhFXT1nJRCxrVRXHNa228XxfLLQzvTBgwHs7Yvsj+XWVlli7VGE0otpRYMkK01xc1NtFfz+2xSZtdFPiub3TYnKMv5bd68VFVMbuaLspossi93fz3xgH+d+T4ry7gqJ9fFMq+e2us95vvMVVFN7ya7g3+bzqsnsfRGfVfkMUj1bP31H9M8z+6a2/nZX13Zdz9evttcw4MLLKvpot51WhZ5I7ZNHrJZq7YO2SgRUL4F9ZbpDwhjwDHne5yyfNbqwseSP/o0YoxqWa5CNS6X/tN+Sdy4EVy9/+k3n7ZEfvBiH/PPefEtH/2a3Rdfs41++jVbRIdn57XedFlG2Z57j4q/37RDkgRKtWEoIYBjXgoXSDJluQ+adEhbIVE9QkJCcEWI5iAketCQKOoGyVZ/DkgE6wyJ0Mcgef+LvxwAJdvEnkCJTK2zAixi4JAabb0C8t5ZTpxJZVspof4oUQwUlwBEBynhg6aEAe+Gyc7hv+TEfICGE6mezcnKRYy5eSWc7DJ7AijAyIigpPZouUTvUduIC/LAQJo0aQVF9wmKrosJI34QFDloUKhjOaFzlJPVN8/HDDpjgo/b8aFiQi9QTpxUQQUIhjuGiTMoU6Z1SIQOQXj/+I+xo8T0SYkyxjAN8iAlatCUKNWNkq3+LJRQd0qOTiYDoWSb2BMoCTIIaazUNiifOs81GXSCgKz3cTZpo8RAj5RIQIrzEnvdTRd2bbrwPJyIuumCTpyIZjg52nRd+k8DwGSX2BM40R44QuJAC1LodJxQAC3G/zkJcPS4sO44YX1ywinGxyPDycB7LtkNk63+HJQg60wJV6+kmmwTewIlSjoHqeaJ8iQsT3QSrGROoFZaIrZXE+yXksgIA3aQkv97rpejpHst4Ud7rmHUkpdouWKfhcAlV1Kq1CY6WOtTBsCFs/F7h1ZIeI+QkKhDwzbGfkjEoCFhTHSjZOfQFyb/AAAA///U191qgzAUAOD7PcXohXc2OfnPQEpr+xhDUpe2MqqSaBnC3n1qN6WDrcgYW29jojk/H3i+YKI6JpRNYaL60UTdBpMxsT9wErdtqRSDzWotN3FMtVquQVBYLZmMhfycitEJ+00nAhgRmPFvnch/7UTBNCbD/r9QwulkJcBu5JdrSOw1JfeP3cZZbl+qpOxeXLtzFQ5VVfoHhBqam224I1hJHWq8www4wzjF4olqlnJDrMVbqQmYedN+zfrnsI14n+X7eVockSkzdCJojNMvxsIkae184SKQvBuCQNLgQuvH82tgg/7qPmtsBDh4b6bospFmB+OTY+H60lautv3icPA8z929vgEAAP//AwA8JF+esCAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:23 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "515f6ec82ffb41b65b78b3e41d4ff263"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1750276936&engagement_id_cursor=5BD75A7E007F0E47FE000A036B605504&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1750320173&engagement_id_cursor=C7268841EBD7ECC398AD1631BA47C678&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+yXXW/bNhSG7/crjFy3AA8PeQ6pO32QxYAtHZZuu+iFIcRKajSROktuMRT776PlryyJXAuxEhvIjSHofFGkHr+vvv80Gp3l10XZjIvyOlzcLi4neZOfjaLRx9H3EA8Zd2LTySJyZhJlnaPEAcWcJootI2qXuEUgltnZm2VlM738XKyrrDJWrwLLocv7TCQBjSU0yKv49ayaf7kbB2OFRWFX8Vnx97yom2K2yjEsiaWRqAyve1RXVyHeTG+LcV1cVuWkbjPXK6jr6XXZPlRTja+ms7oZz4ovN/88qBD/W/NtUdfhqh5fVvOyeRhf9Jg+Fm6qJr8Zbxf+LZ82D2bRevE3VRmGNHvnX37Ky7K4aU/nV3dxEb/7+fzd+hjuHGDd5LNF17yuyjY5bvehmHTmLka2mVJI/VbQW7AfhIkERgIeKSrKSWeJioS592qEGc28Xo5qS87dX4+nhMZtwsX7X/50WcfkOw/2R/m5rL6Vo9+L2+prsc7PvxazULD3vi6azuuQ9si5h4x/33RDIkFnKjFOhR8WWULoMTacJYk0KVvqgMTScJAgCk1SC2VxJyR41JDA5gn3pGRb8IyYSGzfeRlpsS8mqxIVoT0NTLYb+wRO0jQDdITIlJLXzjNLtNKIJCgLoOzkhIbkhEMbxQZ2ckJHzQn3xIRfjpIgJtSbEqlPgxI+ACSZ9AETa5xFsGhAsiIR7nnnvQOhOiHhISEJYsLAajckr47rYJCA6g8JnAYkh3BcEIOVKnWQCR0IkTrVmZNxrA0Qhe+TTkjMgJBIJFQ6tDppx6X7UbIteF5MQLZa0sdxLUpUpE5ES7Yb+wROLAuA2DntgpYIaX3swStv0QO71HZzYofkJPCKWv7gy+TIHVdPMeGXEZMlJaB7U/LAjB8pJXwAMVFKaMUyRggvZ+pj6TN0nJLQxrDf2tX7kLAYEpIgJjqYOj5hSDbfbfs6LnpBSLb2aW9IJJ8GJJt9fQokSSBDA2WJBQ0pQWasjdNYU6LR7oAEBoSEAFAbuVHKV8c1JCYUCRnpXlpCreMSP8Lk/W/u/Ag4OYjlSgxkVjiv2RBISFliqlIlHFvFcYKdoMgBQdEEKnQh2AkKHzUo3FNN+IXUhFrL1UtN6JTUhA+gJjFKwxwMTkACg/PymmzMCSC74MCSpBMSHBISqxmk3uS8Wq6hIeH+kNz//3weLfkPAAD//7RWyQ6CMBC9+xWGAzfotLTUmhC/xJBSyxLCkrYYQ+K/y6ISTp68zv7y3mTmjz/X8ToHeq1+uLSfCw9mZaF0rrdnhMaolVmQEzhxEQjIgWJGARTEt0hQxSTRGjIuCJbhOHXTtg4mxEXVFqHqGiT7Ct0J2nDay0ZMqgZjO5NgziAWlAnu77b14/+1sP4yuq1GnWDw32JK9kLySmnTpjMLtc4MejF+E9cLfHi+AAAA//8DAEwteZ+sIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:24 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "253894e59199ffe74fb2c0cfec77e788"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1750320173&engagement_id_cursor=C7268841EBD7ECC398AD1631BA47C678&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1750694597&engagement_id_cursor=A3287735947A32A3F569A7B137E3CFBB&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SXXW+bMBSG7/croly3ku1j+9jcATbVpK2d1m672EWEEppFTaALpNVU7b/P5HtNSIPSNPQGWbzv8TE2j87x04dWqx33k7ToJGnfDUblsBcXcbvltX62npzuHGvaoFcq7QB9IzUXIQNEHy0BA8KaKLTaoEZsn80ii0H3LllEaa6Rz4VZ0tl7lJJRUFqCApzr/XE2uV/XqdJEA9FzfZz8niR5kYznHoUAyKgAgnzhyW5vnV4MRkknT7pZ2stLJyxWkOeDfjr9qCLr3A7GedEZJ/fDPxsR5L81j5I8d6O8080mabGpl3MMtslFVsTDzmrhj/Gg2MhFiZjbh1nqshT7B3R/xWmaDKfn89leX/sXHy8vFgexdoR5EY/LaeM8S6dmf7oTSa/SW+acOhlh4pzIcwY3jHiEeUJvCUrSXmUI9zh/9nO4HMUkn6WahlzaH9stbuKp4frq03drKjKvfdi39C7NHtPW12SUPSQLf/yQjF3A/htbzjrJnW/L0TvH37NqTqhBgmADPzCgiM8MGqulFaAlBRrYSk7EMTlBAcKhSHdyIhrNCWI9TJb+t6cEPMprUwL0JUquvtjLBmCy3NgDKPG1BYNIQRslAwom8g0ySYJIKBVxVkmJPCIlUivKGVLcSQk2mhJZs5jI09US8BitTQmT74QS+Qq1JAyjSFHLAy6MBC61cSWK8VBaJo0JnpfVFSV4REq0IFwRpWEnJc2uJRTq9lxwCk74DZlVE7E3J7MQ4QF5Jz0XvAInfqAphr41viFRFPqGM259kBHVgWLaVHKijsiJcg9K2LKn3M4J5Y0GRct6nCz9p8CEk9qY0BfLSTMwWe7rITcTIaOIhCwCoVjo/lDmBzwIDTBlADbazxUl+oiUaMq4lmLp2U4JI42mRKp6lCz9b08J98j+TdeCEqLfS9OlDsckssrdAywxQoVCsFAwKg1qE1HLVEgqryaKHA8TTiUH5Zq/3U0XNJoSSuo2XeRETRcvqwlRdTjhJVoC3gknq509BJTQoLuLYOBrHiCJhFScEqMFKB9lZCtBoccEhaEARgXuBEW+GSj/AAAA///U18tOg0AUBuC9T2G66I4yZ+7HhBhamLcwhFJ6iSk0QI1p4rsLVMGa2IpaS7cwZ2AuX2b+n0Bp4ts3nTTtL8GEss5M+JVkk2Zef4HEcwlqr8whRk9Q+u6YGWUEcE7E2Lj4+frZIqHnPU24oFrCUSSq10hkx2QiL5RMaiSsUzKpkbArSSbyD5KJqwTxtC8FZ0IyQO0bZnyhEeSEG+BfIuFnRCKUVhQQjp8kfb9y0W5K2oL/ZQK0YgLYgUlVIj6kmX4zaSf2lJPbh6rhIImfi2BT9bzN9quwLIpNfmfbO5aEU2tOiVZoIZkTDoITEhE5Y8gjEdI4JlOFFMLRrvxanD9a5ZAXq2QxitK1HW5W9hO124Hm9+3CBNE2y9PMgZJkKUUgDg+8vr8/RXZY/3q+2sUOkOHbZnION9JgGebBOs3qpS2ybVw/bAr303bz8goAAP//AwDCwLxwsyAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:24 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "db5671543411613b4885c54b10388ba0"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1750694597&engagement_id_cursor=A3287735947A32A3F569A7B137E3CFBB&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1750766599&engagement_id_cursor=A750D8E6543563198EF3FE58916C4F14&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA+zX3W/bNhAA8Pf9FUaeW4DkHY+k30SRLAp06bD042EPhhArmdFE6iy5xVDsfx/lDzlrIjeCq8QC9qb47kT5xF94/vbLZHKWXedFPcuL63hx21zOszo7m0wnf0y+xXjMuBNbzJvImYIgHQrHBQhjgnUuJEkwnFzKlEjC2YtNZb24/JTvqgwaLbeBzaKbzxWR4KANgQa1jV8vy9Xnu3GuDTPAzDa+zP9a5VWdL7c5WgGSIGUYR77NKa+uYrxe3OazKr8si3nVZOLuCapqcV2sv1Rdzq4Wy6qeLfPPN3/fq2D/eebbvKriVTW7LFdFfT/e3GPxULgu6+xmtn/wr9mivreW2jXopiziIvWj8y//zIoiv1m/nV/9xUXy6vX5q91ruPMCqzpbNnfNqrJYJyfrPuTzztxmyXWmYEK+ZPRS4DsupgymgA8U5cW8swSnaL7bGnGNelVtllqXnPuPD6fEG68TLt6++eBdx8p3vtj74lNRfi0mv+e35Zd8l599yZex4NF9bW66qmLaA+89ZvzzohsJd4TWOiU9BY8EqfFaiMAEivg5l51IaEgkTJJWwsBBJPKkkRD2Q9LmPwcSZP2R4I+QvP3Nn5+AkraxRyghACUDeJU6pIaFVJh40t5x74PnnUrUgEq0NAgAoz5KOO/JZF/wxE6occKhj5NYIqdMjcTJvrNHQAEZd6+hRAUhMYnDjmGerFYGuGTeds9cekAohpFBiUwehEInDUWLfk7a/OdgArwnE5xKGMfM1fb1CCSJ9zJu3UAGtIbgmDVoXSqZEDyJI1gnEjMgEq2UQi7pMBJz0khI9UPS5j8HEuyPBPVIzpK2sUcokQJAJwoDeoyDVmoteOk1S8CTl/fGz1aJYcMpkUzHHydGKHVQCZy0Es57niX7gqd1Iliz6fcD1COcNCVyKs1InOw7ewQUgwx1iGcI4+jiseLQE6rAtBEmDl/dUPiAUDjToPk+5/+Za2AmAnszQRoJk58xdIHiPp4iDpB5ZlPL4y6WQiiUqRLERacSMaASxpBDHL74QSX6pJWMZOjaKAHor4SNRMnPGLpcqsi6YEX8Dy6FJUuJAeOsZAoh1d/Pn3slMKASIUkbacyohy7G+zHZFzylE/mOxU0vpkw/2smmJP6eGc3Q1Xb2CCg6gAGVpkhAXqkgQaeJIBn/BOtt0gkFh4RCykQmPzhO8KShKOrnpM1/DiaC92YC6omZ/AsAAP//IjebwAOWUC5RiAUpVMpLrSiJLwAZXFoEiYWMkpKCYit9/SrjvMQk3TQjAwtzS11LgzRgo8fUxMAg2cAsxdjSJNk00Sg11SDJ3NLIMFGvCmhbanG2LtDH6Zl56XrJ+bn6iQWZ+mVG+gh/FtsjIiY+ubSoOL/I1tDc1MDCAJT41VByK0yeUIZVAzu9OLMq1dbQQA2amGxRE5JSRmJxfG5+EThqS4pKU8GCcI2QwoWrFgAAAP//AwAq8+w4siAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:25 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "8aa3930b7596b3e3f09c67a155c43b27"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1750766599&engagement_id_cursor=A750D8E6543563198EF3FE58916C4F14&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1750809741&engagement_id_cursor=8F3937CC4636E77F538CA2656363BEBA&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SXS2/jNhDH7/spDB9y2mw4fAxJA0FBSdSiQJstNtv2UBSG1mYcI7GUSnK2zWK/eynZsfKyEyFxYh0MCJ7/8DHkjzPz/V2v108mLi2HLp34j1n1OU7KpN8b9P7qffd2r7hhm44rSx8lQUWsDTjTlogINTGEKc2lAU0x7L9feJbT0Zm79tJca7E0LCZd/C8RKXhnZIrJpX2SZ/OLm3ZQmmhG9NKeu3/mrihdvtQoyQTVVKLC1RjZyYm3l9OZGxZulKXjolKuVlAU00lab6rMhifTvCiHubs4/++eB7m15pkrCv9VDEfZPC3v26sxpg+Zy6xMzofNwr8l0/LeXIhL9XmW+knKJ+tHp0mauvP6dH61x8fm489HH6+P4cYBFmWSV6MmRZbWYlPHwY3XaqspayUlVOwT3KfiCyEDQgdUPuDk0vFaFzZg7M7V8HOU82IxVe3y6Td79LDGj1wrjj/98oeN1kx9Y2e/p2dp9i3tfXaz7NJd65NLl3uHJwe2GnReeNkDB+8VP96vpyRiUcwNIzRWxgpLlFYCAA3EBnkc3Q1FQwlukRLOpEYtGNtICd9pSoDIdpg0Dq/MCa8uPaFtOPEufMB1RzhpIvsMUILIoJARMsaElrFPKDG1QRSZMI6MFrAWFLlFUJhmCigSsREU3GlQVEtO1FtiAqo9JqIjmKgXoERp7XEIueSoA2OojAL/mmMgIsuYlXItJWqb6QQ5BwYKNlIid5qSrhRdNSUUW1PCaEcoeYmii9k4lJRGUkKAMjQguVWWB1HIuNXh3bzaUKK3SIlvl4BQvdJ0sTUBCu0waRxemRNVNSe8VdGl6mzSleakiexz0glnKgjCWAIPAVEyFkkd+xedypAjmIdBEYSQbYIisGqRYHN3onYaFEVbFl30zTDxvYlsjQntSm+yCuwzKKGaMWIBQ0XBGml1gCA1wTCKOVG4nhLYJiWcgJZSyI2U6J2mBFu2JvhGrUlNCbQquhaUdCWZ4Au0Jowya/wvFBGA0QSoIAqMEZQx5CGupYRujxJkoAUHgM2U8J2mBIC0w6RxeF1OKKmKLtEmm1Quvui627fe4+TI/rkDmDSBfQYnwtpIxrE1YSACITUi1yxkSmrQ3Dcqazlh2+SEapBEPJJN5E5zIlU7TFb616ekZTZZUMJ4R7LJKrDPoCTgLPZvN4iAgLQSYiICLUzI/XsexWZ9zcW3SQnTwH3lBx2mBLFlzYVvSElTQD2Zks50JqvAPkZJ7+9K2E/dv+Xwohp4ni9O4bQsL4rBwcEVS5Ov+yeU+Byyr8kJ4SA4ISOCY6b5SCTUOfJVagrJhys/myvO9v2OJ9N08mGUzQ6Si+nBJT1o9ln81BzMcDTPiyw/BOnLOQWKsL1btF7bHwN2r156Mb1yh0D2lpfp8PZF6p8mxXCW5fXRlvnc1X+uHOsUTN79+B8AAP//AwBSD8L7syAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:25 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "983ec473579f1a507623108b13f0218e"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1750809741&engagement_id_cursor=8F3937CC4636E77F538CA2656363BEBA&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1750881803&engagement_id_cursor=B43F19515B017E71F05B95AC4954DFAA&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SXTW/aQBCG7/0ViHMi7ez3cFuv11GlNqmafhx6QBY4FAXsFJtEVdT/3rX5LMEkFiWBC7KYd3bWs3407z6+a7Xa8SBJi26SDvzDuHzsx0XcbnVaP1qPPu4Va7Fhv4y0BQrqHLEcMCKGcca5Y9Zq61RAnODts1lmMezdJossFISIeWBWdPa/kpIC0yiZZmoeH0yy6d16HDQSZATn8Unya5rkRTKZa7RiUvhdeJVe1Mhubny8GI6Tbp70srSfl0q22EGeDwdp9VJF1r0ZTvKiO0nuRr+fZJB/9jxO8tw/5d1eNk2Lp/FyjeG2cJEV8ai72vhDPCye1AJYdGCUpb5K8fKE3s84TZNRdT4f3fW1uXh/ebE4iLUjzIt4Ui4b51laiU3ViaRfqy1rVkpKqDgn8pzKL4R0CO0wtSUpSfu1KbzDNj8OX6OY5rNSVcrVJ3e5XeNXrhTXVx++ubCm9NqbfU1v0+whbX1Oxtl9stDH98nEJ7y8s+Wq09zrtpy9V/w5qwfFKC1DEJZqy411TqtQSaQY0MiECqAWFHlIULRUiBLYTlDUUYOiaTNOlvq3wEQ0xwTwOUwu3fcjoGTZ1z0ggUCGhEbCkkgSjUwHKnAuAuSRQQuyFhJ1SEiI4JQoVDsh0UcNicRmkCz1rw8J6xDRHJJTmSXLxu5BiZAcVRAyqgy3WkdSck4jbhnhRgitainRB6REcS40o7h7lPCjpgSAN8NklfDKnPDmw4SXnIhNn3GsnKw6uwcozEgVMhYS7VwYWTDEgcDIKBUB0bTec+FBQaFcCMJ2j5Mj91zQ0HPBm2HCOtBonFSYsE2ncayYLBu7ByXW+VuItRKoICgQFUFuA2dCoC6gAamjBMghKQHOJWotTpiSUzFdFSWUNqfkVIbJ/zBdTPnrCEjFiHVKi8hQFrmA0RAQuTdetZTAASlBoAggYbfpYkdNCSx3/2LTxd6GE12aLsAmnOjqckJPhJNVZ/cAhROwTkQaDYJ3WtLfCQxoa1wYeBvmNi9qK1DoIUHhVPqfZ0yXfDVQ/gIAAP//3Ndfb4IwEADw932KxQffkF7bo+0SsqDIt1gIsqpkEQh/loVk330FNokPasjmpnuFHrR3/aW9/3zp6piwUb2JbE8glDfC5CcuXXNvweYU0VcoqUTgHji+h0wgCZZBEBxVwi6sRDLqwEkl8qqVOHKckv34v1DCR7UmvRJ2I0r2if2GkqXwOQClivmUOQvJwXgRgi2J55jzRRxVwi+nRIBEJdDM6aQSvGolQPg4JkPA7zoB2jpBGOGkDTHNCd6IkyGz56DcP7UDJ6l+q8K8/XJd9GXYVlVePth2w9JoZa0pkUJZiqwJB+SExMR5ZorHGFGtyUooCtGsMX/T5YtllrxJ0s0sznZ2lCf2K7WHhZaPQ2XCuC7KrHDBHFGKKeNgegD26/05s9Nu6mXSaBfI9HM3uYc7abKNynCXFV1tq6LW3cN9YJ+2u/cPAAAA//8DAPENNHi2IAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:26 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "0459fbcd39491f710f52cd017d44f523"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1750881803&engagement_id_cursor=B43F19515B017E71F05B95AC4954DFAA&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:27",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1750939371&engagement_id_cursor=E7D4112293D236C841D95773E0A69A97&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SXTW/jNhCG7/0VRs67AGdIzpC+kZS4KNBmi6btHnowjFhJjU2krSXvolj0v5fyZ5pE3hUSJfZN8LzDoYZ8/I6+/jAanU2vi7KZFOV1erhtH2fTZno2Go/+HH1N8aS4E5vP2sgZK8UKPWQas5jbPFhvgRnQeWPzLJy9WWc288uPxTbLagF6E1gXXf/ORAjSWJJG8iZ+vaiWn+7GwVhhpbCb+KL4e1nUTbHYaAxLRlSCUEq50VRXVynezG+LSV1cVuWsbpW03UFdz6/L1Us11eRqvqibyaL4dPPPgwzxvz3fFnWdnurJZbUsm4fxdo35Y+GmaqY3k/3Gv0znzYNavN3eTVWmIs136y//mpZlcbM6nZ/ziwv37sfzd9tjuHOAdTNdtKtO66pcid2qD8WsU9uWXClRoH4r6C3Sb4BjIcdCP5JUlLPOFDVGuHc1Uo1mWa9LrVLO8w+PS9LCK8HF+5/+yLOOynde7PfyY1l9KUe/FrfV52Krn34uFinhu/vaLrqsk+yRc0+Kf990Q+LY5UHmLuRep3tp2CK00LgAKmSmGxIaEhIgCSz0KUNCuh8kO/1rQALYGxLgb0Hy/pf8/Ago2TX2CZQENiJjFclLFw07rSIqw8r4CMF51UkJD0iJNNqi1AYOUqKOmhIQPb1kn/DCnNBY4FhxH06o5UTKE+Fk39kngOKDtjEIRSL6wErnQAbQAugc2aHvBMUMCIqSEi3x7o/gFO2ETT9OdvqXxyTNXL3sZIUJihPBZNfYJ1ACbDgIsNJEci5df6MxCAaKUWiBppMSOyglAoUme3jo4qOmhHq6Cb2emaShS/SmBOhEKKFn8JIYfbq6HoPEGLPMZSonTV5ZE1KI77diRwmKASkhwWniMnh46MKjpgQE98Nkn/CynKBohy5BPThpU+RYf3PoOs8/HAEm+8Y+5eMkmoSFdWncSv7hhIjgWWGkjIMN8X4r9pzAsJyQ0Kz5ICf6qDnhnm7Cr+Mma0pQ9qZE2hNxE34GN8nZkJcKCNFqMj6ZiFVOhCyg95pjJyU4JCWoQBvLh2eu4/4yOZGZa0OJ7U+JPg0veY6Ri4SzwQrHacCyIX0MQDBgkYiNA+lCJyRyQEiMSmbCYA6PXPKoIQHQ/SjZJwyFyX8AAAD//8yX32uDMBDH3/dXlD74ZnP51ZiCDNfav2CvRVKXtjKqkmgZwv73We2UwlZXxpivyV2Su+99uMtXmIhnaDCh3o8xaV3Ygg6OXCNpJn1mfwPKkmEIwrUEDqGch5yHZEmIoCu8fgqC1begsL8EhWOOAbPboIhRg+KR+zjp7P8DEy7uxgQPzlzj6CZdXocgmWzOhtNUvxVRfj64NK0Ih6LI7QKhiqZq6+4IeEK6EnZQjzwMIIb5C5Us5opoDVshCVazqr5N21e3jnifpPtZnB2RyhN0IqiP0z72ukRxaWxmfCw4SI9wIZwrWD/3h3h1mqfbpNI+BudSS/51HU0PykbHzDTKFqbUzWLn2P7nHt4/AAAA//8DAM44EhewIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:27 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "3d32a64f3a0aa0c319d2ff7a1d726625"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1750939371&engagement_id_cursor=E7D4112293D236C841D95773E0A69A97&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:27",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1750982577&engagement_id_cursor=6C410AEF9050E96E55E2C2273D1FBAAD&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXX2/bNhAA8Pd9CiPPLXDH41+/USRVDNjSYem2hz0YRqxkRhOps+QWQ7HvPkq2ZS+xvGiuY+tNyN2REulfyPv63Wh0Nb3P8mqS5ffx4bF+nE2r6dVoPPp99DXGY8ZObD6rI1cyoST1QggQEMA6xwwTPEmEo6CMs1dvVpXV/PZjtqkyAphYB1aTrv6upGRI2kjSpNbx+0Wx/LQbR23AEJh1fJH9uczKKlusc7QipUkIlILjOqe4u4vxav6YTcrstshnZTPa5g3Kcn6fNx9VFZO7+aKsJovs08NfzyrgX+/8mJVlfCont8Uyr57H6zHm+8JVUU0fJtsX/zKdV8/mkpvXeyjyOEn14vzbP6Z5nj00u/NjuLmx776/frfZhp0NLKvpoh51WhZ5k2ybdchmnbn1lE0mi9v3FuRbpj4AjIHGIPcUZfmss4SPkZ78NOIc1bJcTdWUvP8pXO/PiSM3GTfvf/g1+I6pd77sl/xjXnzJRz9nj8XnbJM//ZwtYsGLF7YedFnGtD0bHzP+ftOtxBlMTYAkSZy1WiWOEm9TlmDiQXjjOpXI0ynRiAqRuDQHlfCLVoLtF76QybbglZ3wMbAxYR8nvHbCYCBOtit7BBQEFX+5ArTioKwDHhRDjU4kgln0uhOKOjEUMtsx9kORFw1FQz8nbf45mHDVmwmogTBpF/YIJYG8V2BJSknccqfQGi6tCIkR1qWsU4k+oRKQKONhomjASoZy6WqUiP+hhA9Eybe4dAUPSjltWTDKAwcTjxKVgpNeJlLQ038YWyXmhEqYlEYisMOtCV20kuFcunTthLE+TnTTnOBAnHyTSxelXHnPjSBLzCEE7Q0XRqFJjUqD6IJCcEoomhEKADHg40Tpfk7a/HMwIdOTCe2cQBfOpF3YI5S4FFCn6NEDKhXQKC4dxK6EGy8psZ1K8MRKKLZKh1sTddFKpOinpM0/h5J+rclKydP7+KUqaRf2GCUguNNaM2YsGR0fuQ/acCdtkJz5TiXshErIEDfK6MOXLnHRShCxH5Ntwes6QVY7QerhpC4ZUHOyXdkjoCTCI2dMkA+JM8amzGqOzDvjVAx1didEJ4QiyPB4osghX7o09HPS5p+DCWFPJvE4+c/e5Dr8dgFK2nU9AgkaEJrJ1FMSUmckCpsQMs5TiQES6kTCT4kEOVG8AtJBJPqikUjVD0mbfxYkfTqTFRIuX/cs+QcAAP//nFbbDsIgDH33K8we9rZRcIiYLH6JWRiyS5ZdAsyYJf67DM2WPWl8LYX29PTQ/r9zsR9Vsr/OjkGnHjYb5odH/WahsnYwZ4SmQyfyqCBwYjziUECCaQIg4Xhzv7qkgigFOeMEi3hy0ZRpIoe4rLsyln2LxFCjO0ErTnNZicnkqE2vU8wodrVmlIcbtS7nXwQb+tRNPakUQ/hppnTbSEElTNb22lNr9ai8cbnoJzDsni8AAAD//wMA1vuAzbMgAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:27 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "f7f5bb58b12f93737d8568719350428b"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1750982577&engagement_id_cursor=6C410AEF9050E96E55E2C2273D1FBAAD&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:28",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1751025759&engagement_id_cursor=1905826FD3BEFC9615AB31244F61E0B3&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXwW7bOBAA0Pt+hZFzC3DI4ZD0jSKpokCbFpt097AHw4iV1GgitZbcoij235eSHTubRLYFV7F9EzwzokzpgTO//hgMzsY3WV6NsvwmXtzVl5NxNT4bDAf/DH7FeMx4EJtO6sgZgnWKJ1xy9EonmicMhU+MdAIkkD17taispldfsvsqI5mQy8Bi0cXvioiD0IaEFmoZv5kV868P46ANM4KZZXyWfZtnZZXNljlaCa0QOTHOYZlTXF/HeDW9y0ZldlXkk7LOFPdPUJbTm7z5U1Uxup7Oymo0y77e/nxSwf73zHdZWcarcnRVzPPqaby+x/S5cFVU49vR+sF/jKfVk7VA4DL9tsjjKtXuBVefx3me3Tbv5324uLBv3p6/uX8RD15hWY1n9W3HZZE3ybbZiWzSmluv2WRyxuVrRq+5ugQaMj4E80xRlk9aS3AoxKOPI65RzcvFUk3Jh4/h/PmceOcmw4d34TL4lrUf/LVP+Ze8+JEP/szuiu/Zff74ezaLBbtvbX3XeRnznnn5MePfVxukSCZDCCDRouIGbbCog/c8JMiESlulUJ9SYhaPTyM2SpFHLUVRNyir/EM4WX/0OzoRQzTbnJyHvzczufjw7q/elaz2dQ8k1qeE8cN0SgdQmjiRSBJvHUeF3rUfJ6pPJIJLQ2wLEjpqJNQRCR0USdfDJCKRp4GEfgMShFSRwdQiYoBEcp8yRz6VIqJJjW9FontEolGSZnKVc5I9F2PdlKwLXpYJZzUTpjowqUsiE3UaTNYbu48TxlPubOqCIOOUQ504ob1ziWYeJW91Ynp0YkATosDNTo684+o4mqjDTCYLJRw6KxFbD5Ptk8nLtFy/YS4B62OrhVJ4QMesSFGDZk6kksfRQFObEmQ9K5FSIZywEpLdlKzyD6KEuiuBE1Gy2th9zhKuPBiliCXBcqOtj7NJAuQTpMTa0KoE+lNigKFiMfGUlQBANybrgpd0oi9Z4wT0zk4WJThk5kR6rtXG7uFEgZNxCHAOnLWGKWeEFS4yiH0XU8njrVg74T064SSFBFJqoxN11E6U7sZklX8IJWL3yWRRIoZya891HEpW+7oHktSClcaBMAy1tylgyiWC96A5A+lakYg+DxNFUgPxzYPJcSMh6thy0QGRIHZHwk4DyWpf90DCbMqD8jJxJoBwxmpAzZVJKYmfqW+fS7BHJIJUPKpIy41I+FEjAdFxMFkXvDATbDou6MIE646LP/44emfyHwAAAP//nFfJCoMwEL33K4oHb5pJotUUpF9SJKZxQVxIYimB/ns1XcRTS6+zv3kzMPPnxUV//Uz258XQ6+XN5OMSeVJPFmpjRn1EyNKeF0FJIE1YwKCcL644AhBwuFAWiZgTKaFIGME8tHM2qdtghlw1fRWKoUN8bNCVoBWoPq3E5GJSelAZTmIMKaUU+5t9feu/razvSteNlRkG/zVM2XaQvJrrvBuUo9aoSTrhx9G1DXb3BwAAAP//AwDlXaMSsSAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:28 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "b1ede75ae2c1c6c5e12789043ffc2776"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1751025759&engagement_id_cursor=1905826FD3BEFC9615AB31244F61E0B3&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:28",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1751083331&engagement_id_cursor=0AF2E7D5BC9E13C9A8148279F6B816D6&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9TXUW/bNhAA4Pf9CiPPLXAkj8ej3yiKKgasabF028MeDCNWMqOJ1Fpyi6LYfx8l23LWRG4Ew7H9Jph3okT5w919/2U0upje5kU9yYvbeHHfXM6m9fRiNB79Pfoe12PEg7X5rFm5sIKcRWlThxlkGXuvhVKA0pHwzOnFq1VmPb/+mG+yrAbU64XVpqvfDZEUii0pVma9frsol58ergu2YBXY9foi/7zMqzpfrGPYKItABrWRmz3Km5u4Xs/v80mVX5fFrGoiBWweoarmt0X7VnU5uZkvqnqyyD/dfXuUAv976Pu8quJVNbkul0X9eL25x/yp5bqsp3eT7ZN/nc7rR3tZXEfflUXcpH52/PU/06LI79rP8zZcXbk3v16+2XyHB1+wqqeL5q7TqizaYNeeQz7rjW22bCMlSP0a6LXkD4BjkGNlnkjKi1lvCo6F+OG/Efeol9VqqzblMvz1dEi8cRtw9e63P0Pas/ODF/uj+FiUX4vR7/l9+SXfxE+/5IuY8OxzbW66rGLYE989Rvz7ql8JZQECKHap055V5jMVkECilM4rr3uV0CGVCI0oEH6iRJy0EuJhSrr4YyhBHqhEjTWdh5LuXPdQkkqwjgJCpnxISQeBXgppKKXEeqF6lZgDKiFU1qqf1RI8aSRCyGFKtgkvzIQbJkIOYcLjtp6cB5Ptwe7hRKOhjFFngbxzSKnOnLScoDDCpcC9TviATrTVLKIVs9OJOWknDMOYdPHHUKJgoJJYTOA8lHTnugcSEdix0+TRG49xGohqUq9IQpJltGMwsYdGwmjVTiR80kjIDEPSxR8FyaC5pEWCZ1JKunPdA0miMQ4gBMGDSEGQ00n8KcSJJBaTSKcPiYYDIjGKBSCQ2InkxDuu7g2f23F1CS/LRMi246IBTJqU2HH9OLQ+YvLufbg8ASfbk90DSpwxtGO26Dx7nQaJFOFokhjAaeN7oYhDQkEjrUW9u5qcdstleJiTLv4YTJQayCS2XOI8qkl3rnsgUVL6kLiMbcaGmcASCtCpViKggn4k8rBIFCgGfcZIiAa2XHREJDhkLlkhQToPJN257oFEiiS1MnY4rFLtnRYsUx2hmDSNk0qS9SJRB0QSiwgJIc+85cJhSrYJL8yE2pZryGTSpMSW60xqyfZg93DiXWIEAKLUnoPVXgYd/6IuQDDGBOh1god0ottyZcxOJ3TSTowexqSLP4YSJQcqicXEHEHJfwAAAP//nFbJCsIwEL37FdJDb20madIaIfglUtKYLkgXklSk4L/bRS09KV5nf7x5w/zzcbEfRbI/T4Feo+8u7abCvVlIKJ3r7BGhIWpkFuQEDgkPOORAMaMACuJLxKlikmgNWcIJluEwdtP2GoyIi6opQtXWSHYVuhG04rSnlZdU9ca2RuBkkl/MGPE3Yn37v+nVn0e31aAFBv+1S2K7R14pbVq3ZmbWmV7Pxk/iclt2jycAAAD//wMAOyG0Pq0gAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:28 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "d356d0290d013160435ae3002aeaa6c0"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1751083331&engagement_id_cursor=0AF2E7D5BC9E13C9A8148279F6B816D6&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1751126552&engagement_id_cursor=CAB71004425C8E95C2E5112AE0E777E0&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SX227bRhCG7/MUgi58Fccze14BRsHDMijQOkWdNhdFITDSWhZikS5JOa2DvHuXlEX6RFuEIpsCDGPB+WcPs/tpZr69GQyG8cwmxdgmMzdYlMNpXMTDwWjw1+CbszvFLdt8WlqGLAwx0tJXHol4iDxCScFXyEKP8SgKhm9XnsV88sWuvTQHzm8Mq0VX36UQBKnSgioqb+yzLF1e3raj0qAp6Bt7Zv9Z2ryw2Y1GSao144JoVs+Rnp05ezFf2HFuJ2kyzUulWO8gz+ezpDpUkY7P5llejDN7efHfAw+4s+eFzXM3yseTdJkUD+3lHPPHzEVaxBfjZuNf43nxcHfrAF2kiVuk2Fg/OY+TxF5Ut/OrOT313v988n59DbcuMC/irJw1ztOkEntVHOy0VVsuWSkJEH4I4pCojyhGQEZUPeJkk2mrCx0xeu9puDWKZb5aqnI5MZ8el7iJK8Hph1/+NGHLyrcO9kfyJUm/JoPf7SK9smt9fGUz57BxXMtJl7mTPXLvTvH9bTskmpmQBsaXnMkgMIHvKxmykGPAqPuDVkjEziBhgCiVW1voJyFhvYYEQXWjpHF4WUwIlJgg64BJ6cKc135g0gR2C048Ql0WQSNQhWhCJKB9LoSgfkAJI7qVE7lLTrhQDEDgHicTqbthUutfg5Lm93BDSlwyuf80HlDy4Tdz0gNM6sBuQQlDTrUhRnDmubTCeEB95NwXWqOR6n5ebShRO6VEATJK6ZOUyF5TIkQ3Smr9q1Aiu1PybMnVE0rqwG5BidGSMgeEJsINIk59ESiXVBiREEaBaaVE75ASojRlismnGxPaa0oQaDdMGoeX5ER/hIoTsnk2Wbm4mmtfOGkiuwUoAh0lBHzP9ShAfI2RBiScgxcY7r61gSJgh6BQ1AqUrJuvx0HhvQZFdkwn8jXSyRoTunlrsnKhI36/b+0rJvIHpBPhIYk8hUQKn+jyheuIRQIjHyPiqq9WSnCXlAAlyNgzrUm/KdmLomtNCeuaTFzRJZ6j5MR86gEkP6LmYhQCQyJfuH/cCCMoelwTT2nXoGDYWnMJskNImHCNkkZ8uuZivYYEEbpR0ji8MCaswkR0wYSVNRfdE0yawG7BiQoCQn3j+x6NQq59iCCgRhLQfuSyDGvlhO6SE6IJ4UzoJzmRveZE6m6Y1PqXp4TeajM2poSQ/aCkjus2FVdAKVIC4F6l40XJACMPmfBDDIWR7X0J2yUkinBgXNI9hkTIbpDU+teABDtVXBUkKPcDkjquz0Ey+LsUDhP7bzG+LCdeZqtLOC+Ky3x0dHRNk/jz4RkBJfWhhjNgyBnABMSUajbhMbEWPktNMH537Vaz+ZdDd+LZPJm9m6SLo/hyfnRFjppz5j819zKeLLM8zY5RckShpYaDO7Cu7c/xelBtPZ9f22OEg5u3dHz3HQ3P43y8SLPqZotsaauPtWOVgOHN9/8BAAD//wMAhA9x564gAAA=",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:29 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "10"
+          ],
+          "x-request-id": [
+            "4da100f570e325614881b2992dd17a5f"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1751126552&engagement_id_cursor=CAB71004425C8E95C2E5112AE0E777E0&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:30",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1751169790&engagement_id_cursor=6C3313200225CC287C1FA146BD1D6E73&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA4ySzW7CMBCE7zxFlHORnP+EG5CAKrUcClUPVRVZZBMiEpvaDrRFvHttQ9q0gMTN8nyzs971vmcYJi6AiBRIIQ+1OmZYYNMYGK/GXuqS6GhlphTTdYaeNUlcH8XjOA78kTuJ47GDRv4QWTYKzLujU5TLNbSuyEO+dxKOocf7wPdtywkj3wmd4KQXjDabrm6FEYocFJ10Bu8NcAHsxISBixTmufZPDZrnUhdlDSmHJSUZV6TTdsB5WRD9KEHTvGRcpAw21eeZA/3puQbO5YmnS9oQca6rGuUlWVCBq/S38R0uxVlW2A6ookSGiJv55QoTApXezmMynw+n97Npu4bOArnATFXFnBIND/UcILvKqkhN2sj2+sjv29EChQNkD5B7wQQku2pxBnb072vIDNHwY5S2zJKXy4gsrIE4eUgWSXwluvOyZ7ImdEeMJ6jpFloeb4FJw82DVUUbLrELi5fEwXhToEngQ6QbVbhhegukqSqtrDBPa8r0QHJccdC3GuXll762eodvAAAA//8DAKjqGiWLAwAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:30 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "8"
+          ],
+          "x-request-id": [
+            "d544244df5395049bf049f9a72394b0e"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time_cursor=1751169790&engagement_id_cursor=6C3313200225CC287C1FA146BD1D6E73&page_size=10&channel=MESSAGING"
       }
     }
   ],

--- a/tests/test_api/betamax/TestEngagementsApi.test_fetch_engagements_with_start_time_start_time.json
+++ b/tests/test_api/betamax/TestEngagementsApi.test_fetch_engagements_with_start_time_start_time.json
@@ -1,0 +1,248 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2025-06-29T08:14:30",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time=1751068800"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SXTW/bRhCG7/kVgg4+xdHMfq+AoFguyaBA6xR10h6KQmAkWhZskS5JOamD/PcuKYv0l2QTqizqRnDe2dmd3Qcz8/1Nr9ePpnFSjOJk6j7m5eckKqJ+b9j7q/fd2Z3ijm02KS19RqSPWkoBXmCIVsYXRHgofI8Jz5ig/3bpWczGF/HKS3NgeGtYBl3+l0IQpEoLqqi8tU+zdHF1145Kg6agb+1Z/M8izos4u9UoSTUCk+CEqxjp2ZmzF7N5PMrjcZpM8lLJVzvI89k0qQ5VpKOzWZYXoyy+uvz3kQfc2/M8znP3lY/G6SIpHtvLNWZPmYu0iC5Hzca/RrPiUSzE1e4v08RFKV7uMD6PkiS+rO7n1+D01Hz4+eTD6iLuXGFeRFm5bJSnSSU2VSbiyVptGbNSEiD8GMQxUZ8AhkCGqJ5wipPJWhc2BP3gcbgYxSJfhqpcToI/n5a4hSvB6cdf/gj8NZHvHOxzcpGkX5Pe7/E8vY5X+ug6zpzDyxNbrrrIne6Jq3eKH2/XcyLRcg7aWrTGaJBWU0Otw0D5FqT3MBUNJ2SHnBDBKUch5UZOZKc5kaodJrV+H5RQ2ZISOuT8MCip87oFJKFBw7VFqoEp34TIQsIZ+j4qAsjtWkjoLouJFFyhIPqAIRGiHSS1fh+QMNYeEjgMSOq8bgEJmJAE0uee1QFSq41CpojUofDcM/XFWkjYDiGhQrpSJRTfCAnpNCRIeTtKGodXxoRVHRe2wYSVHRd5+Dg6ikmT2C040SiMZkT7hoUQhspajpS6V2oEWqX8tZzwHXLCQEjGJdnMCUKnQdGsHSe1fh+YtGu5KkwasrqNSZ3XLSgRYQABUGV8w62ioQ1pwAQQRoix1D5sPhtKxC4pQc4YMniGEuw0JaLlYCL2NJhUlDDVkhLXcx1IMRH/w2DiE9BGBAxCagNf8ACZJUika7e8cl5ZS4ncISWCUa3pc7WEdRoSRNKOksbhlTFRVc9F2mCihlU9OQxMmsRuwQlnUoSK8TAQ1hgmfB4aopXHUKLxQa3lRO2QE665G5Golhs5kZ3mREE7TGr9Piih0JISV0zgMCip87oFJBgoowwXlllpmZsGHDW+pYKAF4Ziw2Cidw2JYppuhER1GhIh20FS6/cCSau5pIKEHUgpqfO6BSQeZ24AERBYQB9QGO65X4GbSFwxceisg4TDDiGRVCEwELgRko53XPUJX9px1Q6viwmSquMSLTApXVzH9XBofYTJx9+Ckw5w0mT2OVB6f5fCfhJ/K0ZX5cqLbHkN50VxlQ8HgxuaRF+OzwgoqY81nAFDzgDGICZUszGPSBzDF6kJRu9uXLQ4vzh2R57Okum7cTofRFezwTUZNAfNf2pu5j1KjiCUAjhq/o7GiyxPs8romkek4ugexiv7cyQfVQfKZzcuDhzdvrH3999X/zzKR/M0q268yBZx9bN2XCbzzY//AAAA//8DAI6mhVnGIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:30 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "5dac5a2a27e8dd9edd0de70e1a65c16d"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time=1751068800"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time=1751068800&start_time_cursor=1751112136&engagement_id_cursor=B542AC60EC01D016A5BB54E3C5B416C4&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SXWW/bRhDH3/MpBD34KY5mj9lDQFDwWAYFWqeIk/ahKARGWsuCLdIlKad1kO/eJXXQh2iLUGVJgB4WnP/s7M7uTzP7/U2n043HNikGNhm7wbQcjuIi7nb6nT87353dKe7ZJqPS0gUu0VNKcy9QAYaGckG9AAXlBjyUQfft3LOYDK/s0ksjIFkY5kHn36UQlDClBVNMLuzjLJ3d3LcTpUEz0At7Zv+e2byw2UKjJNOSS6o1R7bQpBcXzl5MpnaQ22GajPJqtuUK8nwyTqpNFengYpLlxSCzN9f/PvGAB2ue2jx3o3wwTGdJ8dRezjFZZy7SIr4e1Av/Fk+Kp6tTC/V1mrggxcb64WWcJPa6Op1fzfm59+Hnsw/LY7h3gHkRZ+WscZ4mldir8mBHjdoyZKWkQPEUxClVnwntA+0ztsbJJqNGF9ZH8uhquBjFLJ+HqlzOzB/rJW7iSnD+8ZffTdgQ+d7GviRXSfot6Xyy0/TWLvXxrc2cw8Z5LSed5U625tyd4sfbZkgYpYHxvUjpSEmlBGjBCWCIjBjOoBkSultIGDAFeMSQCNEOkpV+H5BwaA0JF8cBySqvW0BCiR9qqggoFmLgIVE0RAeKDEMeSD9qhITtEBJXRAQhVJBnIeEHDQkB3o6S2uGVMRElJkS2wcS58D4cSS2pE7sFJ4HnSwLAOcVAGY0BNeiuqGfASCkNNHLCd8kJVuVKymc5EQfNicR2mKz0+6CE0ZaUuGIij4OSVV63gISHIYm09JVHIwwJRsQ1O74iPPQ4RlFzx4W7hMQVE6o5O2ZIREtIxF4hUe0hYccBifgfINHchMw9TCRyGQQm8H0lQx4iCThzv+ZKInYGCQdCpHKxhX4WkkPvuFQ7SmqH18WEQtVx8RaYlC6u46LHgUmd2C048ShzVYQYQVRITEgoaB+FEMwPGOVUN3Iid8kJCsUBXniZHHYxkbodJiv9Piip/w83pMQVk8dX4wklH38zZweAySqx27RcBJk21AjknisrHAPmE0RfaE2MVI/rak2J2iklCghnjD1LiTxoSoRoR8lKvxdKZHtKXmy5DoSSVWK3oMRoybgDQlPhBhEyXwTKFRVOJYRRYBop0TukhCrNuOLy+YcJO2hKCLB2mNQOr8mJ/gwVJ3TzajJ3cT3XsXBSZ3YLUARxlFDwPfdGAeprEmkgFBG8wKD71gSKgB2CwohWoOTq8bUeFDxoUGTLciL3UU6WmLDNnyZzF9bHx+/WQ8VEblpOOn+Vwm5i/ykGN+XEs2x+CpdFcZP3e707lsRfTy+ou5r6VMMFuF7MvQ2GIEZM8yHG1Fr4KjUl8bs7F83mV6dux+NJMn43TKe9+GbSu6W9ep/5T/XBvCcSCQilAE7qr4PhLMvTrDK6Lo8hP3nA8NL+EsYn1YbyyZ2LAyeLK/b+4fXqXsb5YJpm1YEX2cxWH1eO87+cNz/+AwAA//8DAA1MKnfEIAAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:31 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "8"
+          ],
+          "x-request-id": [
+            "d3495c146b824c04fa78a1780ce23024"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time=1751068800&start_time_cursor=1751112136&engagement_id_cursor=B542AC60EC01D016A5BB54E3C5B416C4&page_size=10&channel=MESSAGING"
+      }
+    },
+    {
+      "recorded_at": "2025-06-29T08:14:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time=1751068800&start_time_cursor=1751155354&engagement_id_cursor=6191E20BAED302B91F9012550ACE5ED3&page_size=10&channel=MESSAGING"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA9SXXWvbMBSG7/crQq5bkI6+rNz5Qy6DroO13S52EUyiZqaJ3FlKyyj775OdxMmaONRk6RowRvh9zznSkR8sP3/o9frZRBs31GbiB7NqOM5c1u8Net97z173jg0tH1dKn4cY0jDAIHgEkgSSy5SmHKcRTgEz1j9bRLp8dK9XUZIhjpfCoujiueAccJWDBEQs9UlZzB82dRxIJAmSS73UP+faOl0uPYGgiCACmNKmRnF353WXz/TQ6lFhxrZystUMrM0npl6UK4Z3eWndsNQP019bEeivOc+0tX5kh6Nibty2XuXId8mucNl0uJ74U5a7rVqcL93Twvgi7tX+0Y/MGD2td+eTur4OLz5eXay2YWMDrcvKKmtmC1Obw7oPetzqrUrWTkDAzhE/B3mD0ADBgKIdQdqMW0PIgPIXr4av4eZ2UaoOuVLfdlt84tpw/fnyq0paKm8s7Nbcm+LJ9L7oWfGoV/7sUZc+4NV9rZLOrbft2Hfv+H3WDgklKFaQRtzfmOKKExwyCWEgI8xwolohgSNCQjlnVGIs9kJC3zUkGKNulKwD3hgTWmPCu2DiQ+iAnAgm68YewEkQx0AiFUUhSRMmI5SimCgBSEap/8rQVk7IMTkBCcAol3s5Ee+aEyG7YdL4354S4q/OlACcBiVNXw+AhMeEYAII+bfS8xKIGKchpjxKcMKVIK2Q0GNCEgBDlAlywpBw0Q2Sxv8/IMGdTlw1JFicBiRNXw86cYUMp4pylMRJ4v9NaJokMUERDxEG9LITa0jYESGpbIwC2X/iIu8akoB1g6TxvzEkQXXeQrQLJEHFFciDIUnUpbr5x5T8AQAA///CE7CEcolCLEihUl5qRUl8Acjg0iJwLOSV5uSAZTISi+Nz84vAAZKWmFOcChYFKy3OrAILm3LVAgAAAP//AwA5clUxIhAAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:31 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "9"
+          ],
+          "x-request-id": [
+            "6655e6475540dc7f45c8c507b5d23a83"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?start_time=1751068800&start_time_cursor=1751155354&engagement_id_cursor=6191E20BAED302B91F9012550ACE5ED3&page_size=10&channel=MESSAGING"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.9.0"
+}

--- a/tests/test_api/betamax/TestEngagementsApi.test_fetch_engagements_with_ticket_id_ticket_id.json
+++ b/tests/test_api/betamax/TestEngagementsApi.test_fetch_engagements_with_ticket_id_ticket_id.json
@@ -1,0 +1,86 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2025-06-29T08:14:32",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic <ZENPY-CREDENTIALS>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "Zenpy/2.0.56"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?ticket_id=94579"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA4ySXU/CMBSG7/0Vy64labd1H9yBDGKimIgfF8YsDTvAwtZi24FK+O+2ZYsokHB30vd5z9ue0+2V47h0DkxlwOa6qEyZU0Vdp+u8OVuta+JAK3KjuDju9wZBP7rBgyhNSUzQkAyTAJHEj3tBGLrXe6cqpktoXUlAoqQR9qH78ygMPezHSejHftToc8Hr1aGO4wQlPmr9Aj5qkApEw8RhEhKCIhIRhBuGz2ZaV0UFmYQpZ7k0pNfeQMpizuyjFM9mhZAqE7Aqv44c6M+dK5BSVzKb8pqpY930KE7JiitaZr8X39BCHWVhRBq85EynqMsN0wVlDEq7n/t0MumNbsejdhEHK5SKCtOWSs4s3LOTgPwsazIt6SGPdFDYQfgJoS7yul50wgQsP2sJutj79zl0hqrlPspaxunraUQ3tsDk4e4lHZxJPnjYM1syvmHOI1R8DS1P1yC04fLBmq611NyJ1Wti57wb0GXwqbKV6VwLuwVWl6VVFlRmFRd2IDNaSrCnFpXFtz3GV7sfAAAA//8DAJrI226NAwAA",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Sun, 29 Jun 2025 08:14:32 GMT"
+          ],
+          "Server": [
+            "openresty"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "content-encoding": [
+            "gzip"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "via": [
+            "zorg"
+          ],
+          "x-envoy-decorator-operation": [
+            "/api/v2/engagements"
+          ],
+          "x-envoy-upstream-service-time": [
+            "13"
+          ],
+          "x-request-id": [
+            "eaa6ad854ad5dd2e649775fe6d0dc903"
+          ],
+          "x-zendesk-zorg": [
+            "yes"
+          ],
+          "zendesk-service": [
+            "agent-engagement-api-service"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://d3v-zenpydev.zendesk.com/api/v2/engagements?ticket_id=94579"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.9.0"
+}

--- a/tests/test_api/test_engagements_api.py
+++ b/tests/test_api/test_engagements_api.py
@@ -1,5 +1,6 @@
 from test_api.fixtures import ZenpyApiTestCase
 from zenpy.lib.api_objects.engagement import Engagement
+from datetime import datetime, timezone
 
 class TestEngagementsApi(ZenpyApiTestCase):
     __test__ = True
@@ -9,8 +10,41 @@ class TestEngagementsApi(ZenpyApiTestCase):
         with self.recorder.use_cassette(
                 cassette_name=cassette_name, serialize_with="prettyjson"
         ):
-            response = self.zenpy_client.engagements()
-            # Validate the response structure
+            response = self.zenpy_client.engagements.fetch_all()
             for engagement in response:
                 self.assertIsInstance(engagement, Engagement)
-                
+
+    def test_fetch_engagements_with_start_time(self):
+        cassette_name = "{}_start_time".format(self.generate_cassette_name())
+        with self.recorder.use_cassette(
+                cassette_name=cassette_name, serialize_with="prettyjson"
+        ):
+            start_time = 1751068800
+            response = self.zenpy_client.engagements.fetch_all(start_time=start_time)
+
+            for engagement in response:
+                self.assertIsInstance(engagement, Engagement)
+                engagement_start_time_epoch = int(datetime.strptime(engagement.engagement_start_time, "%Y-%m-%dT%H:%M:%S").replace(tzinfo=timezone.utc).timestamp())
+                self.assertGreaterEqual(engagement_start_time_epoch, start_time)
+
+    def test_fetch_engagements_with_ticket_id(self):
+        cassette_name = "{}_ticket_id".format(self.generate_cassette_name())
+        with self.recorder.use_cassette(
+                cassette_name=cassette_name, serialize_with="prettyjson"
+        ):
+            ticket_id = 94579
+            response = self.zenpy_client.engagements.fetch_all(ticket_id=ticket_id)
+
+            for engagement in response:
+                self.assertIsInstance(engagement, Engagement)
+                self.assertEqual(engagement.ticket_id, ticket_id)
+
+    def test_fetch_engagement_by_id(self):
+        cassette_name = "{}_engagement_id".format(self.generate_cassette_name())
+        with self.recorder.use_cassette(
+                cassette_name=cassette_name, serialize_with="prettyjson"
+        ):
+            engagement_id = "C604EBEFC12F6FFB0B38EEC7F6A8B5EF"
+            response = self.zenpy_client.engagements.fetch_by_id(engagement_id)
+
+            self.assertEqual(response.engagement_id, engagement_id)

--- a/tests/test_api/test_engagements_api.py
+++ b/tests/test_api/test_engagements_api.py
@@ -1,0 +1,16 @@
+from test_api.fixtures import ZenpyApiTestCase
+from zenpy.lib.api_objects.engagement import Engagement
+
+class TestEngagementsApi(ZenpyApiTestCase):
+    __test__ = True
+
+    def test_fetch_engagements(self):
+        cassette_name = "{}".format(self.generate_cassette_name())
+        with self.recorder.use_cassette(
+                cassette_name=cassette_name, serialize_with="prettyjson"
+        ):
+            response = self.zenpy_client.engagements()
+            # Validate the response structure
+            for engagement in response:
+                self.assertIsInstance(engagement, Engagement)
+                

--- a/zenpy/__init__.py
+++ b/zenpy/__init__.py
@@ -46,7 +46,8 @@ from zenpy.lib.api import (
     ZISApi,
     WebhooksApi,
     LocalesApi,
-    CustomStatusesApi
+    CustomStatusesApi,
+    EngagementApi
 )
 
 from zenpy.lib.cache import ZenpyCache, ZenpyCacheManager
@@ -192,6 +193,7 @@ class Zenpy(object):
         self.webhooks = WebhooksApi(config)
         self.locales = LocalesApi(config)
         self.custom_statuses = CustomStatusesApi(config)
+        self.engagements = EngagementApi(config)
 
     @staticmethod
     def http_adapter_kwargs():

--- a/zenpy/lib/api.py
+++ b/zenpy/lib/api.py
@@ -37,7 +37,7 @@ from zenpy.lib.response import AccountResponseHandler, AgentResponseHandler, \
     BanResponseHandler, \
     ChatResponseHandler, ChatSearchResponseHandler, \
     CombinationResponseHandler, CountResponseHandler, DeleteResponseHandler, \
-    DepartmentResponseHandler, GenericZendeskResponseHandler, \
+    DepartmentResponseHandler, EngagementResponseHandler, GenericZendeskResponseHandler, \
     GoalResponseHandler, HTTPOKResponseHandler, JobStatusesResponseHandler, \
     MissingTranslationHandler, RequestCommentResponseHandler, \
     SearchExportResponseHandler, SearchResponseHandler, ShortcutResponseHandler, \
@@ -97,6 +97,7 @@ class BaseApi(object):
             WebhookInvocationAttemptsResponseHandler,
             WebhooksResponseHandler,
             VoiceCommentResponseHandler,
+            EngagementResponseHandler,
             GenericZendeskResponseHandler,
             HTTPOKResponseHandler,
         )
@@ -3162,3 +3163,13 @@ class CustomStatusesApi(CRUDApi):
 
     def delete(self, api_objects, **kwargs):
         raise ZenpyException("Custom status cannot be deleted")
+
+class EngagementApi(Api):
+    def __init__(self, config):
+        super(EngagementApi, self).__init__(config,
+                                            object_type='agent_engagement_data',
+                                            endpoint=EndpointFactory('engagements'))
+        self._object_mapping = ZendeskObjectMapping(self)
+
+    def __call__(self, *args, **kwargs):
+        return self._query_zendesk(self.endpoint, self.object_type, *args, **kwargs)        

--- a/zenpy/lib/api.py
+++ b/zenpy/lib/api.py
@@ -3165,11 +3165,27 @@ class CustomStatusesApi(CRUDApi):
         raise ZenpyException("Custom status cannot be deleted")
 
 class EngagementApi(Api):
-    def __init__(self, config):
-        super(EngagementApi, self).__init__(config,
-                                            object_type='agent_engagement_data',
-                                            endpoint=EndpointFactory('engagements'))
-        self._object_mapping = ZendeskObjectMapping(self)
+    """
+    API class for handling Engagements.
+    """
 
-    def __call__(self, *args, **kwargs):
-        return self._query_zendesk(self.endpoint, self.object_type, *args, **kwargs)        
+    def __init__(self, config):
+        super(EngagementApi, self).__init__(config, object_type="engagement", endpoint=None)
+
+    def fetch_all(self, **kwargs):
+        """
+        Fetch all engagements with optional query parameters.
+
+        :param kwargs: Query parameters for filtering engagements.
+        :return: ZendeskResultGenerator for engagements.
+        """
+        return self._query_zendesk(self.endpoint, self.object_type, **kwargs)
+
+    def fetch_by_id(self, engagement_id):
+        """
+        Fetch a single engagement by ID.
+
+        :param engagement_id: ID of the engagement to fetch.
+        :return: Engagement object.
+        """
+        return self._query_zendesk(self.endpoint, self.object_type, id=engagement_id)

--- a/zenpy/lib/api_objects/engagement.py
+++ b/zenpy/lib/api_objects/engagement.py
@@ -1,0 +1,59 @@
+from zenpy.lib.api_objects import BaseObject
+
+class Engagement(BaseObject):
+    def __init__(
+        self,
+        engagement_id=None,
+        ticket_id=None,
+        agent_id=None,
+        group_id=None,
+        requester_id=None,
+        offer_time_seconds=None,
+        assignment_to_first_reply_time_seconds=None,
+        average_requester_wait_time_seconds=None,
+        agent_messages_count=None,
+        agent_replies_count=None,
+        total_requester_wait_time_seconds=None,
+        longest_requester_wait_time_seconds=None,
+        channel=None,
+        engagement_start_reason=None,
+        engagement_start_time=None,
+        engagement_end_time=None,
+        ticket_status_start=None,
+        ticket_status_end=None,
+        engagement_end_reason=None,
+        end_user_messages_count=None,
+        api=None,
+        **kwargs
+    ):
+        self.engagement_id = engagement_id
+        self.ticket_id = ticket_id
+        self.agent_id = agent_id
+        self.group_id = group_id
+        self.requester_id = requester_id
+        self.offer_time_seconds = offer_time_seconds
+        self.assignment_to_first_reply_time_seconds = assignment_to_first_reply_time_seconds
+        self.average_requester_wait_time_seconds = average_requester_wait_time_seconds
+        self.agent_messages_count = agent_messages_count
+        self.agent_replies_count = agent_replies_count
+        self.total_requester_wait_time_seconds = total_requester_wait_time_seconds
+        self.longest_requester_wait_time_seconds = longest_requester_wait_time_seconds
+        self.channel = channel
+        self.engagement_start_reason = engagement_start_reason
+        self.engagement_start_time = engagement_start_time
+        self.engagement_end_time = engagement_end_time
+        self.ticket_status_start = ticket_status_start
+        self.ticket_status_end = ticket_status_end
+        self.engagement_end_reason = engagement_end_reason
+        self.end_user_messages_count = end_user_messages_count
+        
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+        for key in self.to_dict():
+            if getattr(self, key) is None:
+                try:
+                    self._dirty_attributes.remove(key)
+                except KeyError:
+                    continue
+                    

--- a/zenpy/lib/endpoint.py
+++ b/zenpy/lib/endpoint.py
@@ -572,6 +572,30 @@ class WebhookEndpoint(BaseEndpoint):
 
         return Url(path, params)
 
+class EngagementEndpoint(BaseEndpoint):
+    def __call__(self, **kwargs):
+        path = self.endpoint
+        params = {}
+        for key, value in kwargs.items():
+            if key == 'agent_id':
+                params['agent_id'] = value
+            elif key == 'channel':
+                params['channel'] = value
+            elif key == 'end_time':
+                params['end_time'] = value
+            elif key == 'filter_by':
+                if value in ['engagement_end_time', 'engagement_start_time']:
+                    params['filter_by'] = value
+                else:
+                    raise ZenpyException("filter_by must be one of (engagement_end_time, engagement_start_time)")
+            elif key == 'page_size':
+                params['page[size]'] = value
+            elif key == 'start_time':
+                params['start_time'] = value
+            elif key == 'ticket_id':
+                params['ticket_id'] = value
+
+        return Url(path, params)
 
 class EndpointFactory(object):
     """
@@ -993,6 +1017,8 @@ class EndpointFactory(object):
         'webhooks/{}/invocations/{}/attempts')
     webhooks.test = WebhookEndpoint('webhooks/test')
     webhooks.secret = SecondaryEndpoint('webhooks/%(id)s/signing_secret')
+
+    engagements = EngagementEndpoint('engagements')
 
     def __new__(cls, endpoint_name):
         return getattr(cls, endpoint_name)

--- a/zenpy/lib/endpoint.py
+++ b/zenpy/lib/endpoint.py
@@ -572,30 +572,22 @@ class WebhookEndpoint(BaseEndpoint):
 
         return Url(path, params)
 
-class EngagementEndpoint(BaseEndpoint):
+class EngagementEndpoint(PrimaryEndpoint):
+    """
+    Custom endpoint for handling Engagements.
+    """
     def __call__(self, **kwargs):
         path = self.endpoint
-        params = {}
-        for key, value in kwargs.items():
-            if key == 'agent_id':
-                params['agent_id'] = value
-            elif key == 'channel':
-                params['channel'] = value
-            elif key == 'end_time':
-                params['end_time'] = value
-            elif key == 'filter_by':
-                if value in ['engagement_end_time', 'engagement_start_time']:
-                    params['filter_by'] = value
-                else:
-                    raise ZenpyException("filter_by must be one of (engagement_end_time, engagement_start_time)")
-            elif key == 'page_size':
-                params['page[size]'] = value
-            elif key == 'start_time':
-                params['start_time'] = value
-            elif key == 'ticket_id':
-                params['ticket_id'] = value
+        parameters = {}
 
-        return Url(path, params)
+        if 'id' in kwargs:
+            path += f"/{kwargs['id']}"
+        else:
+            for key, value in kwargs.items():
+                if key in ('agent_id', 'channel', 'end_time', 'filter_by', 'page_size', 'start_time', 'ticket_id'):
+                    parameters[key] = value
+
+        return Url(path=path, params=parameters)
 
 class EndpointFactory(object):
     """

--- a/zenpy/lib/generator.py
+++ b/zenpy/lib/generator.py
@@ -429,18 +429,21 @@ class EngagementResultGenerator(BaseResultGenerator):
 
     def process_page(self):
         """ Process the current page of results. """
-        response_objects = self._response_json.get('agent_engagement_data', [])
-        return [self.response_handler.api._object_mapping.object_from_json('engagement', obj) for obj in response_objects]
-
+        if "agent_engagement_data" in self._response_json:
+            response_objects = self._response_json.get("agent_engagement_data", [])
+            return [self.response_handler.api._object_mapping.object_from_json("engagement", obj) for obj in response_objects]
+        elif "engagement_id" in self._response_json:
+            return self.response_handler.api._object_mapping.object_from_json("engagement", self._response_json)
+        return []
 
     def get_next_page(self, **kwargs):
         """ Retrieve the next page of results using the `next_page_url` key. """
-        url = self._response_json.get('next_page_url')
+        url = self._response_json.get("next_page_url")
         if url:
-            log.debug(f'There are more results via url={url}, retrieving')
+            log.debug(f"There are more results via url={url}, retrieving")
             response = self.response_handler.api._get(url, raw_response=True)
             return response.json()
         else:
-            log.debug('No more results available, stopping iteration')
+            log.debug("No more results available, stopping iteration")
             raise StopIteration()
             

--- a/zenpy/lib/generator.py
+++ b/zenpy/lib/generator.py
@@ -418,3 +418,29 @@ class ChatIncrementalResultGenerator(BaseResultGenerator):
 class ViewResultGenerator(BaseResultGenerator):
     def process_page(self):
         return self.response_handler.deserialize(self._response_json)
+
+class EngagementResultGenerator(BaseResultGenerator):
+    """
+    Generator for engagement objects using BaseResultGenerator.
+    """
+    def __init__(self, response_handler, response_json):
+        super(EngagementResultGenerator, self).__init__(response_handler, response_json)
+        self.values = self.process_page()
+
+    def process_page(self):
+        """ Process the current page of results. """
+        response_objects = self._response_json.get('agent_engagement_data', [])
+        return [self.response_handler.api._object_mapping.object_from_json('engagement', obj) for obj in response_objects]
+
+
+    def get_next_page(self, **kwargs):
+        """ Retrieve the next page of results using the `next_page_url` key. """
+        url = self._response_json.get('next_page_url')
+        if url:
+            log.debug(f'There are more results via url={url}, retrieving')
+            response = self.response_handler.api._get(url, raw_response=True)
+            return response.json()
+        else:
+            log.debug('No more results available, stopping iteration')
+            raise StopIteration()
+            

--- a/zenpy/lib/mapping.py
+++ b/zenpy/lib/mapping.py
@@ -134,6 +134,7 @@ from zenpy.lib.api_objects.zis_objects import Integration
 from zenpy.lib.exception import ZenpyException
 from zenpy.lib.proxy import ProxyDict, ProxyList
 from zenpy.lib.util import as_singular, get_object_type
+from zenpy.lib.api_objects.engagement import Engagement
 
 log = logging.getLogger(__name__)
 
@@ -233,7 +234,9 @@ class ZendeskObjectMapping(object):
         'signing_secret': WebhookSecret,
         'subscription' : Subscription,
         'vote': Vote,
-        'custom_status': CustomStatus
+        'custom_status': CustomStatus,
+        'engagement': Engagement,
+        'agent_engagement_data': [Engagement]
     }
 
     skip_attrs = []

--- a/zenpy/lib/response.py
+++ b/zenpy/lib/response.py
@@ -12,7 +12,8 @@ from zenpy.lib.generator import (
     SearchExportResultGenerator,
     WebhookInvocationsResultGenerator,
     WebhooksResultGenerator,
-    GenericCursorResultsGenerator
+    GenericCursorResultsGenerator,
+    EngagementResultGenerator
 )
 from zenpy.lib.util import as_singular, as_plural, get_endpoint_path
 from six.moves.urllib.parse import urlparse
@@ -635,3 +636,13 @@ class VoiceCommentResponseHandler(GenericZendeskResponseHandler):
 
     def build(self, response):
         return response.json()
+
+class EngagementResponseHandler(GenericZendeskResponseHandler):
+    """ Handles Engagement API responses. """
+    @staticmethod
+    def applies_to(api, response):
+        return get_endpoint_path(api, response).startswith('/engagements')
+
+    def build(self, response):
+        response_json = response.json()
+        return EngagementResultGenerator(self, response_json)


### PR DESCRIPTION
**Implemented Omnichannel Engagements APIs** 

https://developer.zendesk.com/api-reference/agent-availability/omnichannel-engagements/omnichannel_engagements/

The necessary tests are included and fully passed:
```
======================================================== test session starts =========================================================
platform linux -- Python 3.12.1, pytest-8.3.5, pluggy-1.6.0
rootdir: /workspaces/zenpy
plugins: anyio-4.9.0, betamax-0.9.0
collected 4 items                                                                                                                    

tests/test_api/test_engagements_api.py ....

========================================================== warnings summary ==========================================================
tests/test_api/test_engagements_api.py::TestEngagementsApi::test_fetch_engagement_by_id
tests/test_api/test_engagements_api.py::TestEngagementsApi::test_fetch_engagements
tests/test_api/test_engagements_api.py::TestEngagementsApi::test_fetch_engagements_with_start_time
tests/test_api/test_engagements_api.py::TestEngagementsApi::test_fetch_engagements_with_ticket_id
  /usr/local/python/3.12.1/lib/python3.12/site-packages/betamax/adapter.py:105: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    now = datetime.utcnow()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================== 4 passed, 4 warnings in 0.49s ====================================================
```
